### PR TITLE
Implement ExpirationPartitionBalanceStrategyWithErrorHandling to fix MemQ capacity allocation bug

### DIFF
--- a/deploy/pom.xml
+++ b/deploy/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>com.pinterest.memq</groupId>
 		<artifactId>memq-parent</artifactId>
-		<version>0.2.21</version>
+		<version>0.2.22-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<artifactId>memq-deploy</artifactId>

--- a/memq-client-all/pom.xml
+++ b/memq-client-all/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>com.pinterest.memq</groupId>
 		<artifactId>memq-parent</artifactId>
-		<version>0.2.21</version>
+		<version>0.2.22-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<artifactId>memq-client-all</artifactId>
@@ -18,7 +18,7 @@
 		<dependency>
 			<groupId>com.pinterest.memq</groupId>
 			<artifactId>memq-client</artifactId>
-			<version>0.2.21</version>
+			<version>0.2.22-SNAPSHOT</version>
 		</dependency>
 	</dependencies>
 	<build>

--- a/memq-client/pom.xml
+++ b/memq-client/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>com.pinterest.memq</groupId>
 		<artifactId>memq-parent</artifactId>
-		<version>0.2.21</version>
+		<version>0.2.22-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<artifactId>memq-client</artifactId>

--- a/memq-commons/pom.xml
+++ b/memq-commons/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>com.pinterest.memq</groupId>
 		<artifactId>memq-parent</artifactId>
-		<version>0.2.21</version>
+		<version>0.2.22-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<artifactId>memq-commons</artifactId>

--- a/memq-commons/src/main/java/com/pinterest/memq/commons/protocol/Broker.java
+++ b/memq-commons/src/main/java/com/pinterest/memq/commons/protocol/Broker.java
@@ -150,7 +150,7 @@ public class Broker implements Packet, Comparable<Broker> {
   public String toString() {
     return "Broker [brokerIP=" + brokerIP + ", brokerPort=" + brokerPort + ", instanceType="
         + instanceType + ", locality=" + locality + ", totalNetworkCapacity=" + totalNetworkCapacity
-        + ", brokerType=" + brokerType + "]";
+        + ", availableNetworkCapacity=" + getAvailableCapacity() + ", brokerType=" + brokerType + "]";
   }
 
   @Override

--- a/memq-examples/pom.xml
+++ b/memq-examples/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>com.pinterest.memq</groupId>
 		<artifactId>memq-parent</artifactId>
-		<version>0.2.21</version>
+		<version>0.2.22-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<artifactId>memq-examples</artifactId>

--- a/memq-python-client/setup.py
+++ b/memq-python-client/setup.py
@@ -17,7 +17,7 @@ long_description = (here / 'README.md').read_text(encoding='utf-8')
 
 setup(
     name='memq-client',  # Required
-    version='0.2.20',  # Required
+    version='0.2.22-SNAPSHOT',  # Required
     description='MemQ Python Client',  # Optional
     long_description=long_description,  # Optional
     long_description_content_type='text/markdown',  # Optional (see note above)

--- a/memq/pom.xml
+++ b/memq/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>com.pinterest.memq</groupId>
 		<artifactId>memq-parent</artifactId>
-		<version>0.2.21</version>
+		<version>0.2.22-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<artifactId>memq</artifactId>

--- a/memq/src/main/java/com/pinterest/memq/core/clustering/Balancer.java
+++ b/memq/src/main/java/com/pinterest/memq/core/clustering/Balancer.java
@@ -50,10 +50,10 @@ public class Balancer implements Runnable {
     this.client = client;
     this.leaderSelector = leaderSelector;
     this.writeBalanceStrategy = config.getClusteringConfig().isEnableExpiration()
-        ? new ExpirationPartitionBalanceStrategy()
+        ? new ExpirationPartitionBalanceStrategyWithAssignmentFreeze()
         : new PartitionBalanceStrategy();
     this.readBalanceStrategy = config.getClusteringConfig().isEnableExpiration()
-        ? new ExpirationPartitionBalanceStrategy()
+        ? new ExpirationPartitionBalanceStrategyWithAssignmentFreeze()
         : new PartitionBalanceStrategy();
   }
 

--- a/memq/src/main/java/com/pinterest/memq/core/clustering/ExpirationPartitionBalanceStrategyWithAssignmentFreeze.java
+++ b/memq/src/main/java/com/pinterest/memq/core/clustering/ExpirationPartitionBalanceStrategyWithAssignmentFreeze.java
@@ -1,0 +1,37 @@
+package com.pinterest.memq.core.clustering;
+
+import com.pinterest.memq.commons.protocol.Broker;
+import com.pinterest.memq.commons.protocol.TopicAssignment;
+import com.pinterest.memq.commons.protocol.TopicConfig;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.logging.Logger;
+
+public class ExpirationPartitionBalanceStrategyWithAssignmentFreeze extends ExpirationPartitionBalanceStrategyWithErrorHandling {
+
+    private static final Logger logger =
+        Logger.getLogger(ExpirationPartitionBalanceStrategyWithAssignmentFreeze.class.getName());
+
+    /**
+     * Use the existing assignment and send alert.
+     * Refresher the topic assignment timestamp.
+     * @param topics
+     * @param brokers
+     * @return brokers
+     */
+    @Override
+    protected Set<Broker> handleBalancerError(Set<TopicConfig> topics, Set<Broker> brokers) {
+        logger.info("Trigger assignment freeze and send alert. Current assignment: " + brokers);
+        this.sendAlert();
+        List<Broker> brokerList = new ArrayList<>(brokers);
+        for (Broker broker : brokerList) {
+            for (TopicAssignment topicAssignment : broker.getAssignedTopics()) {
+                topicAssignment.setAssignmentTimestamp(System.currentTimeMillis());
+            }
+        }
+        return new HashSet<>(brokers);
+    }
+}

--- a/memq/src/main/java/com/pinterest/memq/core/clustering/ExpirationPartitionBalanceStrategyWithErrorHandling.java
+++ b/memq/src/main/java/com/pinterest/memq/core/clustering/ExpirationPartitionBalanceStrategyWithErrorHandling.java
@@ -1,0 +1,188 @@
+/**
+ * Copyright 2022 Pinterest, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.pinterest.memq.core.clustering;
+
+import com.codahale.metrics.MetricRegistry;
+import com.pinterest.memq.commons.protocol.Broker;
+import com.pinterest.memq.commons.protocol.TopicAssignment;
+import com.pinterest.memq.commons.protocol.TopicConfig;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.PriorityQueue;
+import java.util.Set;
+import java.util.logging.Logger;
+import java.util.stream.Collectors;
+
+/**
+ * This class is a copy of ExpirationPartitionBalanceStrategyWithErrorHandling.java.
+ * The only difference is it has methods called handleBalancerError and sendAlert.
+ * When the balancer encounters an error, it will call handleBalancerError method and use its result.
+ * The handleBalancerError method is abstract and must be implemented by the subclass.
+ */
+public abstract class ExpirationPartitionBalanceStrategyWithErrorHandling extends BalanceStrategy {
+
+  private long defaultExpirationTime = 300_000; // 5 minutes
+  private MetricRegistry registry = new MetricRegistry();
+  private static final String ALERT_METRIC = "governor.balancer.error";
+  private static final int DEFAULT_CAPACITY = 200;
+  private static final Logger logger = Logger.getLogger(ExpirationPartitionBalanceStrategyWithErrorHandling.class.getName());
+  private Map<String, Integer> instanceTypeThroughputMap = new HashMap<>();
+
+  @Override
+  public Set<Broker> balance(Set<TopicConfig> topics, Set<Broker> brokers) {
+    boolean balancerError = false;
+    List<Broker> oldBrokerList = new ArrayList<>(brokers);
+    Collections.sort(oldBrokerList);
+
+    List<Broker> newBrokerList = new ArrayList<>();
+
+    List<TopicConfig> topicsList = new ArrayList<>(topics);
+    Collections.sort(topicsList);
+
+    long now = System.currentTimeMillis();
+
+    // establish base assignment from sticky (non-expired) assignments
+    for (Broker b : oldBrokerList) {
+      Set<TopicAssignment> brokerStickyAssignments = b.getAssignedTopics()
+          .stream()
+          .filter(topicAssignment -> topicAssignment.getAssignmentTimestamp() + defaultExpirationTime
+              > now)
+          .collect(Collectors.toSet());
+      Broker newBroker = new Broker(b);
+      newBroker.setAssignedTopics(brokerStickyAssignments);
+      newBrokerList.add(newBroker);
+    }
+
+    Map<String, PriorityQueue<Broker>> rackBrokerCapacityMap = new HashMap<>();
+    for (Broker broker : newBrokerList) {
+      Integer capacity = instanceTypeThroughputMap.getOrDefault(broker.getInstanceType(),
+          DEFAULT_CAPACITY);
+      broker.setTotalNetworkCapacity(capacity);
+      PriorityQueue<Broker> priorityQueue = rackBrokerCapacityMap.computeIfAbsent(
+          broker.getLocality(),
+          k -> new PriorityQueue<>(Comparator.comparingInt(Broker::getAvailableCapacity).reversed())
+      );
+      priorityQueue.add(broker);
+    }
+
+    int racks = rackBrokerCapacityMap.size();
+
+    for (TopicConfig topicConfig : topicsList) {
+      String topic = topicConfig.getTopic();
+      double inputTrafficMB = topicConfig.getInputTrafficMB();
+      double ceil = (Math.floor((inputTrafficMB * 1024 * 1024 / (topicConfig.getBatchSizeBytes() * topicConfig.getClusteringMultiplier()))));
+      logger.fine("(" + topic + ")" + " ceil:" + ceil);
+      int partitions = (int) (Math.round(ceil / racks)) * racks;
+      if (partitions < racks) {
+        partitions = racks;
+      }
+
+      int trafficPerPartition = (int) (inputTrafficMB / partitions);
+      logger.info("(" + topic + ")" + " partitions:" + partitions + " traffic:" + inputTrafficMB
+          + " partitions:" + partitions + " trafficPerPartition:" + trafficPerPartition);
+
+      for (Map.Entry<String, PriorityQueue<Broker>> entry : rackBrokerCapacityMap.entrySet()) {
+        int partitionsPerRack = partitions / racks;
+        List<Broker> dequeuedBrokers = new ArrayList<>();
+        List<Broker> ineligibleBrokers = new ArrayList<>();
+        PriorityQueue<Broker> queue = entry.getValue();
+
+        TopicAssignment assignment = new TopicAssignment(topicConfig, trafficPerPartition);
+        while (!queue.isEmpty()) {
+          Broker broker = queue.poll();
+          if (broker.getAssignedTopics().contains(assignment)) {
+            ineligibleBrokers.add(broker);
+            broker.getAssignedTopics().remove(assignment);
+            broker.getAssignedTopics().add(assignment); // update configs/traffic/timestamp
+            partitionsPerRack--;
+          } else {
+            dequeuedBrokers.add(broker);
+          }
+        }
+        if (partitionsPerRack < 0) {
+          PriorityQueue<Broker> utilizationSortedBrokers = new PriorityQueue<>(
+              Comparator.comparingInt(Broker::getAvailableCapacity).reversed()
+          );
+          utilizationSortedBrokers.addAll(ineligibleBrokers);
+          for (int i = partitionsPerRack; i < 0; i++) {
+            Broker b = utilizationSortedBrokers.poll();
+            if (b != null) {
+              b.getAssignedTopics().remove(assignment);
+            }
+          }
+        }
+        queue.addAll(dequeuedBrokers);
+        dequeuedBrokers.clear();
+        if (partitionsPerRack > queue.size()) {
+          logger.severe("Insufficient number of nodes to host this topic:" + topic + " partitions:"
+              + partitionsPerRack + " nodes:" + queue.size());
+          balancerError = true;
+          break;
+        } else if (partitionsPerRack > 0) {
+          for (int i = 0; i < partitionsPerRack; i++) {
+            Broker broker = queue.poll();
+            dequeuedBrokers.add(broker);
+            if (broker == null || broker.getAssignedTopics() == null) {
+              logger.info("Failed to initialize broker assigned topic set, skipping broker");
+              continue;
+            }
+            if (broker.getAssignedTopics().contains(assignment)) {
+              broker.getAssignedTopics().remove(assignment);
+              broker.getAssignedTopics().add(assignment);
+              logger.info(
+                  i + " Topic(" + topic + ") already assigned to node " + broker.getBrokerIP() + ", updating configs");
+            } else if (broker.getAvailableCapacity() - trafficPerPartition > 0) {
+              broker.getAssignedTopics().add(assignment);
+              logger.info("(" + topic + ") assigned to broker:" + broker.getBrokerIP());
+            } else {
+              logger.severe(i + " (" + topic + ") Insufficient capacity left on nodes:" + broker
+                  + " needed:" + trafficPerPartition + "\n" + queue);
+            }
+          }
+        }
+        queue.addAll(ineligibleBrokers);
+        queue.addAll(dequeuedBrokers);
+      }
+    }
+    if (balancerError) {
+      return handleBalancerError(topics, brokers);
+    }
+    return new HashSet<>(newBrokerList);
+  }
+
+  public void setDefaultExpirationTime(long defaultExpirationTime) {
+    this.defaultExpirationTime = defaultExpirationTime;
+  }
+
+  private void printRackStatus(Map<String, PriorityQueue<Broker>> rackBrokerCapacityMap) {
+    logger.info("Rack Status:");
+    for (Map.Entry<String, PriorityQueue<Broker>> entry2 : rackBrokerCapacityMap.entrySet()) {
+      logger.info("Rack:" + entry2.getKey() + "\n\t" + entry2.getValue());
+    }
+  }
+
+  protected abstract Set<Broker> handleBalancerError(Set<TopicConfig> topics, Set<Broker> brokers);
+
+  protected void sendAlert() {
+    registry.counter(ALERT_METRIC).inc();
+  }
+}

--- a/memq/src/main/java/com/pinterest/memq/core/clustering/ExpirationPartitionBalanceStrategyWithErrorHandling.java
+++ b/memq/src/main/java/com/pinterest/memq/core/clustering/ExpirationPartitionBalanceStrategyWithErrorHandling.java
@@ -133,7 +133,7 @@ public abstract class ExpirationPartitionBalanceStrategyWithErrorHandling extend
         queue.addAll(dequeuedBrokers);
         dequeuedBrokers.clear();
         if (partitionsPerRack > queue.size()) {
-          logger.severe("Insufficient number of nodes to host this topic:" + topic + " partitions:"
+          logger.severe("Insufficient number of nodes in rack " + entry.getKey() + " to host this topic:" + topic + " partitions:"
               + partitionsPerRack + " nodes:" + queue.size());
           balancerError = true;
           break;
@@ -155,7 +155,7 @@ public abstract class ExpirationPartitionBalanceStrategyWithErrorHandling extend
               logger.info("(" + topic + ") assigned to broker:" + broker.getBrokerIP());
             } else {
               logger.severe(i + " (" + topic + ") Insufficient capacity left on nodes:" + broker
-                  + " needed:" + trafficPerPartition + "\n" + queue);
+                  + " needed:" + trafficPerPartition + " / available:" + broker.getAvailableCapacity() + "\nqueue: " + queue);
             }
           }
         }

--- a/memq/src/test/java/com/pinterest/memq/core/clustering/TestExpirationPartitionBalanceStrategy.java
+++ b/memq/src/test/java/com/pinterest/memq/core/clustering/TestExpirationPartitionBalanceStrategy.java
@@ -24,6 +24,8 @@ import com.pinterest.memq.commons.protocol.TopicConfig;
 import com.pinterest.memq.commons.protocol.Broker.BrokerType;
 import com.google.common.collect.Sets;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
 import java.util.Arrays;
 import java.util.HashMap;
@@ -32,12 +34,23 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 
+@RunWith(Parameterized.class)
 public class TestExpirationPartitionBalanceStrategy {
+
+  @Parameterized.Parameters(name = "Class: {0}")
+  public static BalanceStrategy[] strategies() {
+    return new BalanceStrategy[] {new ExpirationPartitionBalanceStrategy(), new ExpirationPartitionBalanceStrategyWithAssignmentFreeze()};
+  }
+
+    private final BalanceStrategy strategy;
+
+  public TestExpirationPartitionBalanceStrategy(BalanceStrategy strategy) {
+    this.strategy = strategy;
+  }
 
   @Test
   public void testExpirationPartitionBalanceStrategy() {
     short port = 9092;
-    BalanceStrategy strategy = new ExpirationPartitionBalanceStrategy();
     Set<Broker> brokers = new HashSet<>(
         Arrays.asList(new Broker("1.1.1.9", port, "c5.2xlarge", "us-east-1c", BrokerType.WRITE, new HashSet<>()),
             new Broker("1.1.1.8", port, "c5.2xlarge", "us-east-1b", BrokerType.WRITE, new HashSet<>()),
@@ -82,7 +95,6 @@ public class TestExpirationPartitionBalanceStrategy {
   @Test
   public void testUpdateConfigs() {
     short port = 9092;
-    BalanceStrategy strategy = new ExpirationPartitionBalanceStrategy();
     Set<Broker> brokers = new HashSet<>(
         Arrays.asList(new Broker("1.1.1.9", port, "c5.2xlarge", "us-east-1c", BrokerType.WRITE, new HashSet<>()),
             new Broker("1.1.1.8", port, "c5.2xlarge", "us-east-1b", BrokerType.WRITE, new HashSet<>()),
@@ -138,7 +150,6 @@ public class TestExpirationPartitionBalanceStrategy {
   @Test
   public void testPartitionBalanceStrategyShrink() {
     short port = 9092;
-    BalanceStrategy strategy = new ExpirationPartitionBalanceStrategy();
     Set<Broker> brokers = new HashSet<>(
         Arrays.asList(new Broker("1.1.1.9", port, "c5.2xlarge", "us-east-1c", BrokerType.WRITE, new HashSet<>()),
             new Broker("1.1.1.8", port, "c5.2xlarge", "us-east-1b", BrokerType.WRITE, new HashSet<>()),
@@ -191,8 +202,10 @@ public class TestExpirationPartitionBalanceStrategy {
   @Test
   public void testExpiringAssignments() throws Exception {
     short port = 9092;
-    ExpirationPartitionBalanceStrategy strategy = new ExpirationPartitionBalanceStrategy();
-    strategy.setDefaultExpirationTime(1000L);
+    if (strategy instanceof ExpirationPartitionBalanceStrategy)
+      ((ExpirationPartitionBalanceStrategy) strategy).setDefaultExpirationTime(1000);
+    else if (strategy instanceof ExpirationPartitionBalanceStrategyWithAssignmentFreeze)
+      ((ExpirationPartitionBalanceStrategyWithAssignmentFreeze) strategy).setDefaultExpirationTime(1000);
     Set<Broker> brokers = new HashSet<>(
         Arrays.asList(new Broker("1.1.1.9", port, "c5.2xlarge", "us-east-1c", BrokerType.WRITE, new HashSet<>()),
             new Broker("1.1.1.8", port, "c5.2xlarge", "us-east-1b", BrokerType.WRITE, new HashSet<>()),

--- a/memq/src/test/java/com/pinterest/memq/core/clustering/TestExpirationPartitionBalanceStrategyWithAssignmentFreeze.java
+++ b/memq/src/test/java/com/pinterest/memq/core/clustering/TestExpirationPartitionBalanceStrategyWithAssignmentFreeze.java
@@ -1,0 +1,90 @@
+package com.pinterest.memq.core.clustering;
+
+import com.pinterest.memq.commons.protocol.Broker;
+import com.pinterest.memq.commons.protocol.TopicConfig;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+
+public class TestExpirationPartitionBalanceStrategyWithAssignmentFreeze {
+
+    private static Broker generateBroker(int index, String localityLetter) throws Exception {
+        return new Broker(
+            "1.1.1." + index,
+            (short) 9092,
+            "c6i.2xlarge",
+            "us-east-1" + localityLetter,
+            Broker.BrokerType.WRITE,
+            new HashSet<>()
+        );
+    }
+
+    private static TopicConfig generateTopicConfig(int index) throws Exception {
+        return new TopicConfig(
+            index,
+            1024 * 1024 * 50,
+            256,
+            "test_topic_" + index,
+            50,
+            0,
+            3
+        );
+    }
+
+    private static int getAssignedTopicsCount(Set<Broker> brokers) {
+        int assigned = 0;
+        for (Broker broker : brokers) {
+            assigned += broker.getAssignedTopics().size();
+        }
+        return assigned;
+    }
+
+    @Test
+    public void testExpirationPartitionBalanceStrategyWithAssignmentFreeze() throws Exception {
+        int expirationTime = 500; // 500ms
+        ExpirationPartitionBalanceStrategyWithAssignmentFreeze strategy = new ExpirationPartitionBalanceStrategyWithAssignmentFreeze();
+        strategy.setDefaultExpirationTime(expirationTime); // 500ms
+
+        // 3 brokers, 1 topic with 450MB input traffic
+        TopicConfig topicConfig = generateTopicConfig(0);
+        topicConfig.setInputTrafficMB(450);
+        Set<TopicConfig> topics = new HashSet<>(Arrays.asList(topicConfig));
+        Set<Broker> brokers = new HashSet<>(
+            Arrays.asList(
+                generateBroker(1, "a"),
+                generateBroker(2, "b"),
+                generateBroker(3, "c")
+            )
+        );
+
+        // topic assigned to all 3 brokers
+        brokers = strategy.balance(topics, brokers);
+        assertEquals(3, getAssignedTopicsCount(brokers));
+
+        // topic requires 6 brokers, but only 3 available, still keep the assignment
+        topicConfig.setInputTrafficMB(900);
+        brokers = strategy.balance(topics, brokers);
+        assertEquals(3, getAssignedTopicsCount(brokers));
+
+        // after expiration, still keep the assignment
+        Thread.sleep(expirationTime); // 1000ms
+        brokers = strategy.balance(topics, brokers);
+        assertEquals(3, getAssignedTopicsCount(brokers));
+
+        // add 3 more brokers, topic should be assigned to all 6 brokers
+        brokers.add(generateBroker(4, "a"));
+        brokers.add(generateBroker(5, "b"));
+        brokers.add(generateBroker(6, "c"));
+        brokers = strategy.balance(topics, brokers);
+        assertEquals(6, getAssignedTopicsCount(brokers));
+
+        // reduce input traffic to 450MB, topic should be assigned to 3 brokers
+        topicConfig.setInputTrafficMB(450);
+        brokers = strategy.balance(topics, brokers);
+        assertEquals(3, getAssignedTopicsCount(brokers));
+    }
+}

--- a/memq/src/test/java/com/pinterest/memq/core/clustering/TestExpirationPartitionBalanceStrategyWithAssignmentFreeze.java
+++ b/memq/src/test/java/com/pinterest/memq/core/clustering/TestExpirationPartitionBalanceStrategyWithAssignmentFreeze.java
@@ -295,7 +295,7 @@ public class TestExpirationPartitionBalanceStrategyWithAssignmentFreeze {
         Thread.sleep(expirationTime * 2);
 
         // topic0 needs 9 brokers, topic1 still needs 6 brokers, but only 12 available in total
-        topicConfig0.setInputTrafficMB(1350);
+        topicConfig0.setInputTrafficMB(1350);   // setting this to 1800 (all 12 brokers) will result in topic1 being fully dropped
 
         brokers = strategy.balance(topics, brokers);
         assignedBrokers0 = getAssignedBrokersForTopic(brokers, topicConfig0.getTopic());

--- a/memq/src/test/java/com/pinterest/memq/core/clustering/TestExpirationPartitionBalanceStrategyWithAssignmentFreeze.java
+++ b/memq/src/test/java/com/pinterest/memq/core/clustering/TestExpirationPartitionBalanceStrategyWithAssignmentFreeze.java
@@ -1,90 +1,567 @@
 package com.pinterest.memq.core.clustering;
 
+import com.google.common.collect.Sets;
 import com.pinterest.memq.commons.protocol.Broker;
+import com.pinterest.memq.commons.protocol.TopicAssignment;
 import com.pinterest.memq.commons.protocol.TopicConfig;
 import org.junit.Test;
 
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class TestExpirationPartitionBalanceStrategyWithAssignmentFreeze {
 
-    private static Broker generateBroker(int index, String localityLetter) throws Exception {
-        return new Broker(
-            "1.1.1." + index,
-            (short) 9092,
-            "c6i.2xlarge",
-            "us-east-1" + localityLetter,
-            Broker.BrokerType.WRITE,
-            new HashSet<>()
-        );
-    }
+    @Test
+    public void testSingleTopicSufficientBrokersBalancedAz() throws Exception {
+        long expirationTime = 500;
+        BalanceStrategy strategy = getExpirationBalanceStrategyWithFreeze(expirationTime);
 
-    private static TopicConfig generateTopicConfig(int index) throws Exception {
-        return new TopicConfig(
-            index,
-            1024 * 1024 * 50,
-            256,
-            "test_topic_" + index,
-            50,
-            0,
-            3
-        );
-    }
+        // 6 brokers, 1 topic with 450MB input traffic
+        TopicConfig topicConfig = generateTopicConfig(0);
+        topicConfig.setInputTrafficMB(450);
+        Set<TopicConfig> topics = new HashSet<>(Arrays.asList(topicConfig));
+        Set<Broker> brokers = getBrokers(2, 2, 2);
 
-    private static int getAssignedTopicsCount(Set<Broker> brokers) {
-        int assigned = 0;
-        for (Broker broker : brokers) {
-            assigned += broker.getAssignedTopics().size();
-        }
-        return assigned;
+        // topic assigned to 3 brokers
+        brokers = strategy.balance(topics, brokers);
+        Set<Broker> assignedBrokers = getAssignedBrokersForTopic(brokers, topicConfig.getTopic());
+        assertEquals(3, assignedBrokers.size());
+        assertLocalityBalance(assignedBrokers);
+
+        // topic requires 6 brokers
+        topicConfig.setInputTrafficMB(900);
+        brokers = strategy.balance(topics, brokers);
+        assignedBrokers = getAssignedBrokersForTopic(brokers, topicConfig.getTopic());
+        assertEquals(6, assignedBrokers.size());
+        assertLocalityBalance(assignedBrokers);
+
+        // after expiration, still keep the assignment
+        Thread.sleep(expirationTime * 2);
+        brokers = strategy.balance(topics, brokers);
+        assignedBrokers = getAssignedBrokersForTopic(brokers, topicConfig.getTopic());
+        assertEquals(6, assignedBrokers.size());
+        assertLocalityBalance(assignedBrokers);
+
+        // reduce input traffic to 450MB, topic should be assigned to 3 brokers
+        topicConfig.setInputTrafficMB(450);
+        brokers = strategy.balance(topics, brokers);
+        assignedBrokers = getAssignedBrokersForTopic(brokers, topicConfig.getTopic());
+        assertEquals(3, assignedBrokers.size());
+        assertLocalityBalance(assignedBrokers);
     }
 
     @Test
-    public void testExpirationPartitionBalanceStrategyWithAssignmentFreeze() throws Exception {
-        int expirationTime = 500; // 500ms
-        ExpirationPartitionBalanceStrategyWithAssignmentFreeze strategy = new ExpirationPartitionBalanceStrategyWithAssignmentFreeze();
-        strategy.setDefaultExpirationTime(expirationTime); // 500ms
+    public void testSingleTopicSufficientBrokersImbalancedAz() throws Exception {
+        long expirationTime = 500;
+        BalanceStrategy strategy = getExpirationBalanceStrategyWithFreeze(expirationTime);
+
+        // 6 brokers, 1 topic with 450MB input traffic
+        TopicConfig topicConfig = generateTopicConfig(0);
+        topicConfig.setInputTrafficMB(450);
+        Set<TopicConfig> topics = new HashSet<>(Arrays.asList(topicConfig));
+        Set<Broker> brokers = getBrokers(2, 2, 2);
+
+        // topic assigned to 3 brokers
+        brokers = strategy.balance(topics, brokers);
+        Set<Broker> assignedBrokers = getAssignedBrokersForTopic(brokers, topicConfig.getTopic());
+        assertEquals(3, assignedBrokers.size());
+        assertLocalityBalance(assignedBrokers);
+
+        Thread.sleep(expirationTime * 2);
+
+        // remove one broker from a
+        Set<Broker> removedA = removeBrokers(brokers, "a", 1);
+        brokers = strategy.balance(topics, brokers);
+        assignedBrokers = getAssignedBrokersForTopic(brokers, topicConfig.getTopic());
+        assertEquals(3, assignedBrokers.size());
+
+        Thread.sleep(expirationTime * 2);
+
+        // remove one broker from b
+        Set<Broker> removedB = removeBrokers(brokers, "b", 1);
+        brokers = strategy.balance(topics, brokers);
+        assignedBrokers = getAssignedBrokersForTopic(brokers, topicConfig.getTopic());
+        assertEquals(3, assignedBrokers.size());
+
+        // remove another broker from b
+        Set<Broker> removedB2 = removeBrokers(brokers, "b", 1);
+        assertEquals(3, brokers.size());
+        brokers = strategy.balance(topics, brokers);
+        assignedBrokers = getAssignedBrokersForTopic(brokers, topicConfig.getTopic());
+        assertEquals(2, assignedBrokers.size());    // only 2 brokers left from previous assignment and it's frozen
+
+        Thread.sleep(expirationTime * 2);
+
+        // add removed brokers from b back
+        brokers.addAll(removedB);
+        brokers.addAll(removedB2);
+
+        brokers = strategy.balance(topics, brokers);
+        assignedBrokers = getAssignedBrokersForTopic(brokers, topicConfig.getTopic());
+        assertEquals(3, assignedBrokers.size());
+
+        // add removed broker from a back
+        brokers.addAll(removedA);
+
+        Thread.sleep(expirationTime * 2);
+
+        brokers = strategy.balance(topics, brokers);
+        assignedBrokers = getAssignedBrokersForTopic(brokers, topicConfig.getTopic());
+        assertEquals(3, assignedBrokers.size());
+    }
+
+    @Test
+    public void testSingleTopicInsufficientBrokersBalancedAz() throws Exception {
+        long expirationTime = 500;
+        BalanceStrategy strategy = getExpirationBalanceStrategyWithFreeze(expirationTime);
 
         // 3 brokers, 1 topic with 450MB input traffic
         TopicConfig topicConfig = generateTopicConfig(0);
         topicConfig.setInputTrafficMB(450);
         Set<TopicConfig> topics = new HashSet<>(Arrays.asList(topicConfig));
-        Set<Broker> brokers = new HashSet<>(
-            Arrays.asList(
-                generateBroker(1, "a"),
-                generateBroker(2, "b"),
-                generateBroker(3, "c")
-            )
-        );
+        Set<Broker> brokers = getBrokers(1, 1, 1);
 
         // topic assigned to all 3 brokers
         brokers = strategy.balance(topics, brokers);
-        assertEquals(3, getAssignedTopicsCount(brokers));
+        Set<Broker> assignedBrokers = getAssignedBrokersForTopic(brokers, topicConfig.getTopic());
+        assertEquals(3, assignedBrokers.size());
+        assertLocalityBalance(assignedBrokers);
 
         // topic requires 6 brokers, but only 3 available, still keep the assignment
         topicConfig.setInputTrafficMB(900);
         brokers = strategy.balance(topics, brokers);
-        assertEquals(3, getAssignedTopicsCount(brokers));
+        assignedBrokers = getAssignedBrokersForTopic(brokers, topicConfig.getTopic());
+        assertEquals(3, assignedBrokers.size());
+        assertLocalityBalance(assignedBrokers);
 
         // after expiration, still keep the assignment
-        Thread.sleep(expirationTime); // 1000ms
+        Thread.sleep(expirationTime * 2);
         brokers = strategy.balance(topics, brokers);
-        assertEquals(3, getAssignedTopicsCount(brokers));
+        assignedBrokers = getAssignedBrokersForTopic(brokers, topicConfig.getTopic());
+        assertEquals(3, assignedBrokers.size());
+        assertLocalityBalance(assignedBrokers);
 
         // add 3 more brokers, topic should be assigned to all 6 brokers
         brokers.add(generateBroker(4, "a"));
         brokers.add(generateBroker(5, "b"));
         brokers.add(generateBroker(6, "c"));
         brokers = strategy.balance(topics, brokers);
-        assertEquals(6, getAssignedTopicsCount(brokers));
+        assignedBrokers = getAssignedBrokersForTopic(brokers, topicConfig.getTopic());
+        assertEquals(6, assignedBrokers.size());
+        assertLocalityBalance(assignedBrokers);
 
         // reduce input traffic to 450MB, topic should be assigned to 3 brokers
         topicConfig.setInputTrafficMB(450);
         brokers = strategy.balance(topics, brokers);
-        assertEquals(3, getAssignedTopicsCount(brokers));
+        assignedBrokers = getAssignedBrokersForTopic(brokers, topicConfig.getTopic());
+        assertEquals(3, assignedBrokers.size());
+        assertLocalityBalance(assignedBrokers);
+    }
+
+    @Test
+    public void testSingleTopicInsufficientBrokersImbalancedAz() throws Exception {
+        long expirationTime = 500;
+        BalanceStrategy strategy = getExpirationBalanceStrategyWithFreeze(expirationTime);
+
+        // 6 brokers, 1 topic with 900MB input traffic
+        TopicConfig topicConfig = generateTopicConfig(0);
+        topicConfig.setInputTrafficMB(900);
+        Set<TopicConfig> topics = new HashSet<>(Arrays.asList(topicConfig));
+        Set<Broker> brokers = getBrokers(2, 2, 2);
+
+        brokers = strategy.balance(topics, brokers);
+        Set<Broker> assignedBrokers = getAssignedBrokersForTopic(brokers, topicConfig.getTopic());
+        assertEquals(6, assignedBrokers.size());
+        assertLocalityBalance(assignedBrokers);
+
+        Thread.sleep(expirationTime * 2);
+
+        Set<Broker> removed = removeBrokers(brokers, "a", 1);
+        brokers = strategy.balance(topics, brokers);
+        assignedBrokers = getAssignedBrokersForTopic(brokers, topicConfig.getTopic());
+        assertEquals(5, assignedBrokers.size());
+
+        Thread.sleep(expirationTime * 2);
+
+        brokers = strategy.balance(topics, brokers);
+        assignedBrokers = getAssignedBrokersForTopic(brokers, topicConfig.getTopic());
+        assertEquals(5, assignedBrokers.size());
+
+        // add removed brokers back
+        brokers.addAll(removed);
+        brokers = strategy.balance(topics, brokers);
+        assignedBrokers = getAssignedBrokersForTopic(brokers, topicConfig.getTopic());
+        assertEquals(6, assignedBrokers.size());
+        assertLocalityBalance(assignedBrokers);
+
+        Thread.sleep(expirationTime * 2);
+
+        brokers = strategy.balance(topics, brokers);
+        assignedBrokers = getAssignedBrokersForTopic(brokers, topicConfig.getTopic());
+        assertEquals(6, assignedBrokers.size());
+        assertLocalityBalance(assignedBrokers);
+    }
+
+    @Test
+    public void testMultiTopicSufficientBrokersBalancedAz() throws Exception {
+        long expirationTime = 500;
+        BalanceStrategy strategy = getExpirationBalanceStrategyWithFreeze(expirationTime);
+
+        // 12 brokers, 2 topics with 450 and 900MB input traffic, 900MB topic has priority
+        TopicConfig topicConfig1 = generateTopicConfig(0);
+        topicConfig1.setInputTrafficMB(450);
+        topicConfig1.setTopicOrder(1000);
+        TopicConfig topicConfig2 = generateTopicConfig(1);
+        topicConfig2.setInputTrafficMB(900);
+        topicConfig2.setTopicOrder(0);
+
+        Set<TopicConfig> topics = new HashSet<>(Arrays.asList(topicConfig1, topicConfig2));
+        Set<Broker> brokers = getBrokers(4, 4, 4);
+
+        // topic 2 assigned to 6 brokers, topic 1 assigned to 3 brokers
+        brokers = strategy.balance(topics, brokers);
+        Set<Broker> assignedBrokers1 = getAssignedBrokersForTopic(brokers, topicConfig1.getTopic());
+        Set<Broker> assignedBrokers2 = getAssignedBrokersForTopic(brokers, topicConfig2.getTopic());
+        assertEquals(3, assignedBrokers1.size());
+        assertEquals(6, assignedBrokers2.size());
+        assertLocalityBalance(assignedBrokers1);
+        assertLocalityBalance(assignedBrokers2);
+
+        // remove all assigned brokers from each AZ for topic 2 and reassign with inputTrafficMB = 450
+        brokers.removeAll(assignedBrokers2);
+        Set<Broker> removed = new HashSet<>(assignedBrokers2);
+        topicConfig2.setInputTrafficMB(450);
+        brokers = strategy.balance(topics, brokers);
+        assignedBrokers2 = getAssignedBrokersForTopic(brokers, topicConfig2.getTopic());
+        assertEquals(3, assignedBrokers2.size());
+        assertLocalityBalance(assignedBrokers2);
+        assertTrue(Sets.intersection(assignedBrokers2, removed).isEmpty());
+
+        topicConfig2.setInputTrafficMB(1350);
+
+        brokers.addAll(removed);
+
+        // topic 2 assigned to 9 brokers, topic 1 assigned to 3 brokers
+        brokers = strategy.balance(topics, brokers);
+        assignedBrokers1 = getAssignedBrokersForTopic(brokers, topicConfig1.getTopic());
+        assignedBrokers2 = getAssignedBrokersForTopic(brokers, topicConfig2.getTopic());
+        assertEquals(3, assignedBrokers1.size());
+        assertEquals(9, assignedBrokers2.size());
+        assertLocalityBalance(assignedBrokers1);
+        assertLocalityBalance(assignedBrokers2);
+
+        Thread.sleep(expirationTime * 2);
+
+        brokers = strategy.balance(topics, brokers);
+        assignedBrokers1 = getAssignedBrokersForTopic(brokers, topicConfig1.getTopic());
+        assignedBrokers2 = getAssignedBrokersForTopic(brokers, topicConfig2.getTopic());
+        assertEquals(3, assignedBrokers1.size());
+        assertEquals(9, assignedBrokers2.size());
+        assertLocalityBalance(assignedBrokers1);
+        assertLocalityBalance(assignedBrokers2);
+    }
+
+    @Test
+    public void testMultiTopicInsufficientBrokersBalancedAz() throws Exception {
+        long expirationTime = 500;
+        BalanceStrategy strategy = getExpirationBalanceStrategyWithFreeze(expirationTime);
+
+        // 12 brokers, 2 topics with 450 and 900MB input traffic, topic0 has priority over topic1
+        TopicConfig topicConfig0 = generateTopicConfig(0);
+        topicConfig0.setInputTrafficMB(450);
+        topicConfig0.setTopicOrder(0);
+        TopicConfig topicConfig1 = generateTopicConfig(1);
+        topicConfig1.setInputTrafficMB(900);
+        topicConfig1.setTopicOrder(1000);
+
+        Set<TopicConfig> topics = new HashSet<>(Arrays.asList(topicConfig0, topicConfig1));
+        Set<Broker> brokers = getBrokers(4, 4, 4);
+
+        brokers = strategy.balance(topics, brokers);
+        Set<Broker> assignedBrokers0 = getAssignedBrokersForTopic(brokers, topicConfig0.getTopic());
+        Set<Broker> assignedBrokers1 = getAssignedBrokersForTopic(brokers, topicConfig1.getTopic());
+        assertEquals(3, assignedBrokers0.size());
+        assertEquals(6, assignedBrokers1.size());
+        assertLocalityBalance(assignedBrokers0);
+        assertLocalityBalance(assignedBrokers1);
+
+        Thread.sleep(expirationTime * 2);
+
+        // topic0 needs 9 brokers, topic1 still needs 6 brokers, but only 12 available in total
+        topicConfig0.setInputTrafficMB(1350);
+
+        brokers = strategy.balance(topics, brokers);
+        assignedBrokers0 = getAssignedBrokersForTopic(brokers, topicConfig0.getTopic());
+        assignedBrokers1 = getAssignedBrokersForTopic(brokers, topicConfig1.getTopic());
+        assertEquals(9, assignedBrokers0.size());
+        assertEquals(3, assignedBrokers1.size());   // TODO: this scenario is concerning because topic1's assignment got dropped
+
+        brokers.add(generateBroker(13, "a"));
+        brokers.add(generateBroker(14, "b"));
+        brokers.add(generateBroker(15, "c"));
+
+        // topic 1 needs 9 brokers, topic 2 needs 6 brokers, 15 brokers available
+        brokers = strategy.balance(topics, brokers);
+        assignedBrokers0 = getAssignedBrokersForTopic(brokers, topicConfig0.getTopic());
+        assignedBrokers1 = getAssignedBrokersForTopic(brokers, topicConfig1.getTopic());
+        assertEquals(9, assignedBrokers0.size());
+        assertEquals(6, assignedBrokers1.size());
+        assertLocalityBalance(assignedBrokers0);
+        assertLocalityBalance(assignedBrokers1);
+
+        Thread.sleep(expirationTime * 2);
+
+        brokers = strategy.balance(topics, brokers);
+        assignedBrokers0 = getAssignedBrokersForTopic(brokers, topicConfig0.getTopic());
+        assignedBrokers1 = getAssignedBrokersForTopic(brokers, topicConfig1.getTopic());
+        assertEquals(9, assignedBrokers0.size());
+        assertEquals(6, assignedBrokers1.size());
+        assertLocalityBalance(assignedBrokers0);
+        assertLocalityBalance(assignedBrokers1);
+
+        // remove 3 brokers, 1 from each AZ
+        Set<Broker> removed = removeBrokers(brokers, "a", 1);
+        removed = Sets.union(removed, removeBrokers(brokers, "b", 1));
+        removed = Sets.union(removed, removeBrokers(brokers, "c", 1));
+
+        assertEquals(12, brokers.size());
+        assertEquals(3, removed.size());
+
+        Set<Broker> removed0 = Sets.intersection(removed, assignedBrokers0);
+        Set<Broker> removed1 = Sets.intersection(removed, assignedBrokers1);
+
+        long now = System.currentTimeMillis();
+        while (System.currentTimeMillis() - now < expirationTime * 2) {
+            brokers = strategy.balance(topics, brokers);
+            assignedBrokers0 = getAssignedBrokersForTopic(brokers, topicConfig0.getTopic());
+            assignedBrokers1 = getAssignedBrokersForTopic(brokers, topicConfig1.getTopic());
+            assertEquals(9 - removed0.size(), assignedBrokers0.size());
+            assertEquals(6 - removed1.size(), assignedBrokers1.size());
+            Thread.sleep(50);
+        }
+
+        brokers.addAll(removed);
+
+        brokers = strategy.balance(topics, brokers);
+        assignedBrokers0 = getAssignedBrokersForTopic(brokers, topicConfig0.getTopic());
+        assignedBrokers1 = getAssignedBrokersForTopic(brokers, topicConfig1.getTopic());
+
+        assertEquals(9, assignedBrokers0.size());
+        assertEquals(6, assignedBrokers1.size());
+    }
+
+    @Test
+    public void testMultiTopicSufficientBrokersImbalancedAz() throws Exception {
+        long expirationTime = 500;
+        BalanceStrategy strategy = getExpirationBalanceStrategyWithFreeze(expirationTime);
+
+        // 12 brokers, 2 topics with 450 and 900MB input traffic, topic0 has priority over topic1
+        TopicConfig topicConfig0 = generateTopicConfig(0);
+        topicConfig0.setInputTrafficMB(450);
+        topicConfig0.setTopicOrder(0);
+        TopicConfig topicConfig1 = generateTopicConfig(1);
+        topicConfig1.setInputTrafficMB(900);
+        topicConfig1.setTopicOrder(1000);
+
+        Set<TopicConfig> topics = new HashSet<>(Arrays.asList(topicConfig0, topicConfig1));
+        Set<Broker> brokers = getBrokers(4, 4, 4);
+
+        brokers = strategy.balance(topics, brokers);
+        Set<Broker> assignedBrokers0 = getAssignedBrokersForTopic(brokers, topicConfig0.getTopic());
+        Set<Broker> assignedBrokers1 = getAssignedBrokersForTopic(brokers, topicConfig1.getTopic());
+        assertEquals(3, assignedBrokers0.size());
+        assertEquals(6, assignedBrokers1.size());
+        assertLocalityBalance(assignedBrokers0);
+        assertLocalityBalance(assignedBrokers1);
+
+        Set<Broker> removed = removeBrokers(brokers, "a", 3);
+        Set<Broker> removed0 = Sets.intersection(removed, assignedBrokers0);
+        Set<Broker> removed1 = Sets.intersection(removed, assignedBrokers1);
+
+        assertEquals(9, brokers.size());
+
+        long now = System.currentTimeMillis();
+        while (System.currentTimeMillis() - now < expirationTime * 2) {
+            brokers = strategy.balance(topics, brokers);
+            assignedBrokers0 = getAssignedBrokersForTopic(brokers, topicConfig0.getTopic());
+            assignedBrokers1 = getAssignedBrokersForTopic(brokers, topicConfig1.getTopic());
+            assertEquals(3 - removed0.size(), assignedBrokers0.size());
+            assertEquals(6 - removed1.size(), assignedBrokers1.size());
+            Thread.sleep(50);
+        }
+
+        brokers.addAll(removed);
+
+        brokers = strategy.balance(topics, brokers);
+        assignedBrokers0 = getAssignedBrokersForTopic(brokers, topicConfig0.getTopic());
+        assignedBrokers1 = getAssignedBrokersForTopic(brokers, topicConfig1.getTopic());
+        assertEquals(3, assignedBrokers0.size());
+        assertEquals(6, assignedBrokers1.size());
+        assertLocalityBalance(assignedBrokers0);
+        assertLocalityBalance(assignedBrokers1);
+
+        Thread.sleep(expirationTime * 2);
+
+        brokers = strategy.balance(topics, brokers);
+        assignedBrokers0 = getAssignedBrokersForTopic(brokers, topicConfig0.getTopic());
+        assignedBrokers1 = getAssignedBrokersForTopic(brokers, topicConfig1.getTopic());
+        assertEquals(3, assignedBrokers0.size());
+        assertEquals(6, assignedBrokers1.size());
+        assertLocalityBalance(assignedBrokers0);
+        assertLocalityBalance(assignedBrokers1);
+    }
+
+    @Test
+    public void testMultiTopicInsufficientBrokersImbalancedAz() throws Exception {
+        long expirationTime = 500;
+        BalanceStrategy strategy = getExpirationBalanceStrategyWithFreeze(expirationTime);
+
+        // 12 brokers, 2 topics with 450 and 900MB input traffic, topic0 has priority over topic1
+        TopicConfig topicConfig0 = generateTopicConfig(0);
+        topicConfig0.setInputTrafficMB(450);
+        topicConfig0.setTopicOrder(0);
+        TopicConfig topicConfig1 = generateTopicConfig(1);
+        topicConfig1.setInputTrafficMB(900);
+        topicConfig1.setTopicOrder(1000);
+
+        Set<TopicConfig> topics = new HashSet<>(Arrays.asList(topicConfig0, topicConfig1));
+        Set<Broker> brokers = getBrokers(3, 3, 3);
+
+        brokers = strategy.balance(topics, brokers);
+        Set<Broker> assignedBrokers0 = getAssignedBrokersForTopic(brokers, topicConfig0.getTopic());
+        Set<Broker> assignedBrokers1 = getAssignedBrokersForTopic(brokers, topicConfig1.getTopic());
+        assertEquals(3, assignedBrokers0.size());
+        assertEquals(6, assignedBrokers1.size());
+        assertLocalityBalance(assignedBrokers0);
+        assertLocalityBalance(assignedBrokers1);
+
+        Set<Broker> removed = removeBrokers(brokers, "a", 2);
+        Set<Broker> removed0 = Sets.intersection(removed, assignedBrokers0);
+        Set<Broker> removed1 = Sets.intersection(removed, assignedBrokers1);
+
+        assertEquals(7, brokers.size());
+        assertTrue(removed0.size() + removed1.size() > 0);
+
+        long now = System.currentTimeMillis();
+        while (System.currentTimeMillis() - now < expirationTime * 2) {
+            brokers = strategy.balance(topics, brokers);
+            assignedBrokers0 = getAssignedBrokersForTopic(brokers, topicConfig0.getTopic());
+            assignedBrokers1 = getAssignedBrokersForTopic(brokers, topicConfig1.getTopic());
+            assertEquals(3 - removed0.size(), assignedBrokers0.size());
+            assertEquals(6 - removed1.size(), assignedBrokers1.size());
+            Thread.sleep(50);
+        }
+
+        brokers.addAll(removed);
+
+        brokers = strategy.balance(topics, brokers);
+        assignedBrokers0 = getAssignedBrokersForTopic(brokers, topicConfig0.getTopic());
+        assignedBrokers1 = getAssignedBrokersForTopic(brokers, topicConfig1.getTopic());
+        assertEquals(3, assignedBrokers0.size());
+        assertEquals(6, assignedBrokers1.size());
+        assertLocalityBalance(assignedBrokers0);
+        assertLocalityBalance(assignedBrokers1);
+    }
+
+    private static BalanceStrategy getExpirationBalanceStrategyWithFreeze(long expirationTime) {
+        ExpirationPartitionBalanceStrategyWithAssignmentFreeze strategy = new ExpirationPartitionBalanceStrategyWithAssignmentFreeze();
+        strategy.setDefaultExpirationTime(expirationTime); // 500ms
+        return strategy;
+    }
+
+    private static BalanceStrategy getExpirationBalanceStrategy(long expirationTime) {
+        ExpirationPartitionBalanceStrategy strategy = new ExpirationPartitionBalanceStrategy();
+        strategy.setDefaultExpirationTime(expirationTime); // 500ms
+        return strategy;
+    }
+
+    private static Set<Broker> getBrokers(int numBrokersA, int numBrokersB, int numBrokersC) throws Exception {
+        Set<Broker> brokers = new HashSet<>();
+        for (int i = 1; i <= numBrokersA + numBrokersB + numBrokersC; i++) {
+            if (i % 3 == 1) {
+                brokers.add(generateBroker(i, "a"));
+            } else if (i % 3 == 2) {
+                brokers.add(generateBroker(i, "b"));
+            } else {
+                brokers.add(generateBroker(i, "c"));
+            }
+        }
+        return brokers;
+    }
+
+    private static Broker generateBroker(int index, String localityLetter) throws Exception {
+        return new Broker(
+                "1.1.1." + index,
+                (short) 9092,
+                "c6i.2xlarge",
+                "us-east-1" + localityLetter,
+                Broker.BrokerType.WRITE,
+                new HashSet<>()
+        );
+    }
+
+    private static TopicConfig generateTopicConfig(int index) throws Exception {
+        return new TopicConfig(
+                index,
+                1024 * 1024 * 50,
+                256,
+                "test_topic_" + index,
+                50,
+                0,
+                3
+        );
+    }
+
+    private static Set<Broker> getAssignedBrokersForTopic(Set<Broker> brokers, String topic) {
+        Set<Broker> assignedBrokers = new HashSet<>();
+        for (Broker broker : brokers) {
+            for (TopicAssignment topicAssignment : broker.getAssignedTopics()) {
+                if (topicAssignment.getTopic().equals(topic)) {
+                    assignedBrokers.add(broker);
+                    break;
+                }
+            }
+        }
+        return assignedBrokers;
+    }
+
+    private static Set<Broker> removeBrokers(Set<Broker> brokers, String localityOfBrokersToRemove, int numBrokersToRemove) {
+        Set<Broker> brokersToRemove = new HashSet<>();
+        for (Broker broker : brokers) {
+            if (broker.getLocality().equals("us-east-1" + localityOfBrokersToRemove)) {
+                brokersToRemove.add(broker);
+                if (brokersToRemove.size() == numBrokersToRemove) {
+                    break;
+                }
+            }
+        }
+        brokers.removeAll(brokersToRemove);
+        return brokersToRemove;
+    }
+
+    private static Set<Broker> removeBrokers(Set<Broker> brokers, String ipToRemove) {
+        Set<Broker> brokersToRemove = new HashSet<>();
+        for (Broker broker : brokers) {
+            if (broker.getBrokerIP().equals(ipToRemove)) {
+                brokersToRemove.add(broker);
+            }
+        }
+        brokers.removeAll(brokersToRemove);
+        return brokersToRemove;
+    }
+
+    private static void assertLocalityBalance(Set<Broker> brokers) {
+        Map<String, Integer> localityCount = new HashMap<>();
+        for (Broker broker: brokers) {
+            localityCount.put(broker.getLocality(), localityCount.getOrDefault(broker.getLocality(), 0) + 1);
+        }
+        assertEquals(1, localityCount.values().stream().collect(Collectors.toSet()).size());
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.pinterest.memq</groupId>
 	<artifactId>memq-parent</artifactId>
-	<version>0.2.21</version>
+	<version>0.2.22-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	<name>memq-parent</name>
 	<description>Hyperscale PubSub System</description>


### PR DESCRIPTION
 ## Overview  
  
The current `ExpirationPartitionBalanceStrategy` has a bug that can lead to insufficient capacity allocation for new topic configurations. If the cluster does not have enough capacity, the assignment logic fails during the assignment process, resulting in only a limited number of brokers being assigned to the topic. It does not maximize the broker usage or keep the current assignment.  
  
## Proposed Solution  
  
To address this issue, we introduce a new strategy called `ExpirationPartitionBalanceStrategyWithErrorHandling`. This strategy includes an abstract method called `handleBalancerError`, which does the assignment process when the main workflow encounters a failure.  
  
## Implementation Details  
  
### ExpirationPartitionBalanceStrategyWithErrorHandling  
  
Introduces error handling for assignment processes with insufficient cluster capacity.  It has an abstract method `handleBalancerError` – This method will execute the assignment work if the main assignment workflow fails.  
  
### ExpirationPartitionBalanceStrategyWithAssignmentFreeze  
  
This class extends `ExpirationPartitionBalanceStrategyWithErrorHandling`.  It overrides handleBalancerError which freezes the current assignment by refreshing the assignment timestamp, then sends an alert to notify engineers about the issue.  Engineers can then fix the configuration or add more capacity to mitigate the problem. 

## Test

Unit tests. The class is also validated by existing unit tests for ExpirationPartitionBalanceStrategy.  