### PR TITLE
Balancer Capacity Check Enhancement  

### DIFF
--- a/memq/src/main/java/com/pinterest/memq/core/clustering/ExpirationPartitionBalanceStrategyWithErrorHandling.java
+++ b/memq/src/main/java/com/pinterest/memq/core/clustering/ExpirationPartitionBalanceStrategyWithErrorHandling.java
@@ -150,7 +150,7 @@ public abstract class ExpirationPartitionBalanceStrategyWithErrorHandling extend
               broker.getAssignedTopics().add(assignment);
               logger.info(
                   i + " Topic(" + topic + ") already assigned to node " + broker.getBrokerIP() + ", updating configs");
-            } else if (broker.getAvailableCapacity() - trafficPerPartition > 0) {
+            } else if (broker.getAvailableCapacity() - trafficPerPartition >= 0) {
               broker.getAssignedTopics().add(assignment);
               logger.info("(" + topic + ") assigned to broker:" + broker.getBrokerIP());
             } else {


### PR DESCRIPTION
## Summary  
  
Update the balancer capacity check to use the `>=` operator. This change prevents insufficient capacity errors in situations where the available free capacity is exactly equal to the required capacity.  