### PR TITLE
Add metrics reporter in ExpirationPartitionBalanceStrategyWithErrorHandling

### DIFF
--- a/memq/pom.xml
+++ b/memq/pom.xml
@@ -139,7 +139,13 @@
 			<artifactId>commons-cli</artifactId>
 			<version>1.4</version>
 		</dependency>
-	</dependencies>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>4.8.1</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
 	<build>
 		<extensions>
 			<extension>

--- a/memq/src/main/java/com/pinterest/memq/core/clustering/BalanceStrategy.java
+++ b/memq/src/main/java/com/pinterest/memq/core/clustering/BalanceStrategy.java
@@ -19,8 +19,18 @@ import java.util.Set;
 
 import com.pinterest.memq.commons.protocol.Broker;
 import com.pinterest.memq.commons.protocol.TopicConfig;
+import com.pinterest.memq.core.config.MemqConfig;
 
 public abstract class BalanceStrategy {
+  protected MemqConfig memqConfig;
 
   public abstract Set<Broker> balance(Set<TopicConfig> topics, Set<Broker> brokers);
+
+  public void setMemqConfig(MemqConfig memqConfig) {
+    this.memqConfig = memqConfig;
+  }
+
+  public MemqConfig getMemqConfig() {
+    return this.memqConfig;
+  }
 }

--- a/memq/src/main/java/com/pinterest/memq/core/clustering/BalanceStrategy.java
+++ b/memq/src/main/java/com/pinterest/memq/core/clustering/BalanceStrategy.java
@@ -22,15 +22,15 @@ import com.pinterest.memq.commons.protocol.TopicConfig;
 import com.pinterest.memq.core.config.MemqConfig;
 
 public abstract class BalanceStrategy {
-  protected MemqConfig memqConfig;
+  protected final MemqConfig memqConfig;
 
   public abstract Set<Broker> balance(Set<TopicConfig> topics, Set<Broker> brokers);
 
-  public void setMemqConfig(MemqConfig memqConfig) {
-    this.memqConfig = memqConfig;
+  public BalanceStrategy() {
+    this.memqConfig = null;
   }
 
-  public MemqConfig getMemqConfig() {
-    return this.memqConfig;
+  public BalanceStrategy(MemqConfig memqConfig) {
+      this.memqConfig = memqConfig;
   }
 }

--- a/memq/src/main/java/com/pinterest/memq/core/clustering/Balancer.java
+++ b/memq/src/main/java/com/pinterest/memq/core/clustering/Balancer.java
@@ -55,6 +55,8 @@ public class Balancer implements Runnable {
     this.readBalanceStrategy = config.getClusteringConfig().isEnableExpiration()
         ? new ExpirationPartitionBalanceStrategyWithAssignmentFreeze()
         : new PartitionBalanceStrategy();
+    this.writeBalanceStrategy.setMemqConfig(config);
+    this.readBalanceStrategy.setMemqConfig(config);
   }
 
   @Override

--- a/memq/src/main/java/com/pinterest/memq/core/clustering/Balancer.java
+++ b/memq/src/main/java/com/pinterest/memq/core/clustering/Balancer.java
@@ -50,13 +50,11 @@ public class Balancer implements Runnable {
     this.client = client;
     this.leaderSelector = leaderSelector;
     this.writeBalanceStrategy = config.getClusteringConfig().isEnableExpiration()
-        ? new ExpirationPartitionBalanceStrategyWithAssignmentFreeze()
+        ? new ExpirationPartitionBalanceStrategyWithAssignmentFreeze(config)
         : new PartitionBalanceStrategy();
     this.readBalanceStrategy = config.getClusteringConfig().isEnableExpiration()
-        ? new ExpirationPartitionBalanceStrategyWithAssignmentFreeze()
+        ? new ExpirationPartitionBalanceStrategyWithAssignmentFreeze(config)
         : new PartitionBalanceStrategy();
-    this.writeBalanceStrategy.setMemqConfig(config);
-    this.readBalanceStrategy.setMemqConfig(config);
   }
 
   @Override

--- a/memq/src/main/java/com/pinterest/memq/core/clustering/ExpirationPartitionBalanceStrategyWithAssignmentFreeze.java
+++ b/memq/src/main/java/com/pinterest/memq/core/clustering/ExpirationPartitionBalanceStrategyWithAssignmentFreeze.java
@@ -3,6 +3,7 @@ package com.pinterest.memq.core.clustering;
 import com.pinterest.memq.commons.protocol.Broker;
 import com.pinterest.memq.commons.protocol.TopicAssignment;
 import com.pinterest.memq.commons.protocol.TopicConfig;
+import com.pinterest.memq.core.config.MemqConfig;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -14,6 +15,10 @@ public class ExpirationPartitionBalanceStrategyWithAssignmentFreeze extends Expi
 
     private static final Logger logger =
         Logger.getLogger(ExpirationPartitionBalanceStrategyWithAssignmentFreeze.class.getName());
+
+    public ExpirationPartitionBalanceStrategyWithAssignmentFreeze(MemqConfig memqConfig) {
+        super(memqConfig);
+    }
 
     /**
      * Use the existing assignment and send alert.

--- a/memq/src/main/java/com/pinterest/memq/core/clustering/ExpirationPartitionBalanceStrategyWithErrorHandling.java
+++ b/memq/src/main/java/com/pinterest/memq/core/clustering/ExpirationPartitionBalanceStrategyWithErrorHandling.java
@@ -15,10 +15,16 @@
  */
 package com.pinterest.memq.core.clustering;
 
+import com.codahale.metrics.Metric;
 import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.ScheduledReporter;
+import com.pinterest.memq.commons.mon.OpenTSDBClient;
+import com.pinterest.memq.commons.mon.OpenTSDBReporter;
 import com.pinterest.memq.commons.protocol.Broker;
 import com.pinterest.memq.commons.protocol.TopicAssignment;
 import com.pinterest.memq.commons.protocol.TopicConfig;
+import com.pinterest.memq.core.config.OpenTsdbConfiguration;
+import com.pinterest.memq.core.utils.MiscUtils;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -29,6 +35,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.PriorityQueue;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
@@ -41,7 +48,7 @@ import java.util.stream.Collectors;
 public abstract class ExpirationPartitionBalanceStrategyWithErrorHandling extends BalanceStrategy {
 
   private long defaultExpirationTime = 300_000; // 5 minutes
-  private MetricRegistry registry = new MetricRegistry();
+  private MetricRegistry registry;
   private static final String ALERT_METRIC = "governor.balancer.error";
   private static final int DEFAULT_CAPACITY = 200;
   private static final Logger logger = Logger.getLogger(ExpirationPartitionBalanceStrategyWithErrorHandling.class.getName());
@@ -183,6 +190,41 @@ public abstract class ExpirationPartitionBalanceStrategyWithErrorHandling extend
   protected abstract Set<Broker> handleBalancerError(Set<TopicConfig> topics, Set<Broker> brokers);
 
   protected void sendAlert() {
-    registry.counter(ALERT_METRIC).inc();
+    logger.info("Sending alert for balancer error.");
+    if (this.registry == null) {
+      try {
+        initializeMetricsRegistry();
+      } catch (Exception e) {
+        logger.severe("Failed to initialize metricsReporter. Cannot send alert." + e.getMessage());
+        return;
+      }
+    }
+    this.registry.counter(ALERT_METRIC).inc();
+  }
+
+  /**
+   * Initialize the metrics registry and the reporter.
+   * @throws Exception if the reporter cannot be initialized.
+   */
+  protected void initializeMetricsRegistry() throws Exception {
+    logger.info("Initializing metrics registry for balancer error.");
+    this.registry = new MetricRegistry();
+    String localHostname = MiscUtils.getHostname();
+    OpenTsdbConfiguration openTsdbConfiguration = this.memqConfig.getOpenTsdbConfig();
+    OpenTSDBClient openTSDBClient = new OpenTSDBClient(
+        openTsdbConfiguration.getHost(),
+        openTsdbConfiguration.getPort()
+    );
+    ScheduledReporter reporter = OpenTSDBReporter.createReporter(
+        "netty",
+        this.registry,
+        ALERT_METRIC,
+        (String name, Metric metric) -> true,
+        TimeUnit.SECONDS,
+        TimeUnit.SECONDS,
+        openTSDBClient,
+        localHostname
+    );
+    reporter.start(openTsdbConfiguration.getFrequencyInSeconds(), TimeUnit.SECONDS);
   }
 }

--- a/memq/src/main/java/com/pinterest/memq/core/clustering/ExpirationPartitionBalanceStrategyWithErrorHandling.java
+++ b/memq/src/main/java/com/pinterest/memq/core/clustering/ExpirationPartitionBalanceStrategyWithErrorHandling.java
@@ -23,6 +23,7 @@ import com.pinterest.memq.commons.mon.OpenTSDBReporter;
 import com.pinterest.memq.commons.protocol.Broker;
 import com.pinterest.memq.commons.protocol.TopicAssignment;
 import com.pinterest.memq.commons.protocol.TopicConfig;
+import com.pinterest.memq.core.config.MemqConfig;
 import com.pinterest.memq.core.config.OpenTsdbConfiguration;
 import com.pinterest.memq.core.utils.MiscUtils;
 
@@ -49,10 +50,14 @@ public abstract class ExpirationPartitionBalanceStrategyWithErrorHandling extend
 
   private long defaultExpirationTime = 300_000; // 5 minutes
   private MetricRegistry registry;
-  private static final String ALERT_METRIC = "governor.balancer.error";
+  private static final String ALERT_METRIC = "balancer.error";
   private static final int DEFAULT_CAPACITY = 200;
   private static final Logger logger = Logger.getLogger(ExpirationPartitionBalanceStrategyWithErrorHandling.class.getName());
   private Map<String, Integer> instanceTypeThroughputMap = new HashMap<>();
+
+  public ExpirationPartitionBalanceStrategyWithErrorHandling(MemqConfig memqConfig) {
+    super(memqConfig);
+  }
 
   @Override
   public Set<Broker> balance(Set<TopicConfig> topics, Set<Broker> brokers) {
@@ -196,10 +201,11 @@ public abstract class ExpirationPartitionBalanceStrategyWithErrorHandling extend
         initializeMetricsRegistry();
       } catch (Exception e) {
         logger.severe("Failed to initialize metricsReporter. Cannot send alert." + e.getMessage());
-        return;
       }
     }
-    this.registry.counter(ALERT_METRIC).inc();
+    if (this.registry != null) {
+      this.registry.counter(ALERT_METRIC).inc();
+    }
   }
 
   /**
@@ -210,13 +216,22 @@ public abstract class ExpirationPartitionBalanceStrategyWithErrorHandling extend
     logger.info("Initializing metrics registry for balancer error.");
     this.registry = new MetricRegistry();
     String localHostname = MiscUtils.getHostname();
+    if (this.memqConfig == null) {
+      // MemqConfig should not be null. This is an error case.
+      throw new Exception("MemqConfig is null. Cannot initialize metrics reporter.");
+    }
+    if (this.memqConfig.getOpenTsdbConfig() == null) {
+      // MemqConfig may not have OpenTsdbConfig. In that case, we cannot initialize metrics reporter.
+      logger.warning("OpenTsdbConfig is null. Cannot initialize metrics reporter.");
+      return;
+    }
     OpenTsdbConfiguration openTsdbConfiguration = this.memqConfig.getOpenTsdbConfig();
     OpenTSDBClient openTSDBClient = new OpenTSDBClient(
         openTsdbConfiguration.getHost(),
         openTsdbConfiguration.getPort()
     );
     ScheduledReporter reporter = OpenTSDBReporter.createReporter(
-        "netty",
+        "governor",
         this.registry,
         ALERT_METRIC,
         (String name, Metric metric) -> true,

--- a/memq/src/test/java/com/pinterest/memq/core/clustering/TestExpirationPartitionBalanceStrategy.java
+++ b/memq/src/test/java/com/pinterest/memq/core/clustering/TestExpirationPartitionBalanceStrategy.java
@@ -23,9 +23,11 @@ import com.pinterest.memq.commons.protocol.Broker;
 import com.pinterest.memq.commons.protocol.TopicConfig;
 import com.pinterest.memq.commons.protocol.Broker.BrokerType;
 import com.google.common.collect.Sets;
+import com.pinterest.memq.core.config.MemqConfig;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.mockito.Mockito;
 
 import java.util.Arrays;
 import java.util.HashMap;
@@ -39,7 +41,9 @@ public class TestExpirationPartitionBalanceStrategy {
 
   @Parameterized.Parameters(name = "Class: {0}")
   public static BalanceStrategy[] strategies() {
-    return new BalanceStrategy[] {new ExpirationPartitionBalanceStrategy(), new ExpirationPartitionBalanceStrategyWithAssignmentFreeze()};
+    MemqConfig mockMemqConfig = Mockito.mock(MemqConfig.class);
+    Mockito.when(mockMemqConfig.getOpenTsdbConfig()).thenReturn(null);
+    return new BalanceStrategy[] {new ExpirationPartitionBalanceStrategy(), new ExpirationPartitionBalanceStrategyWithAssignmentFreeze(mockMemqConfig)};
   }
 
     private final BalanceStrategy strategy;

--- a/memq/src/test/java/com/pinterest/memq/core/clustering/TestExpirationPartitionBalanceStrategyWithAssignmentFreeze.java
+++ b/memq/src/test/java/com/pinterest/memq/core/clustering/TestExpirationPartitionBalanceStrategyWithAssignmentFreeze.java
@@ -4,7 +4,9 @@ import com.google.common.collect.Sets;
 import com.pinterest.memq.commons.protocol.Broker;
 import com.pinterest.memq.commons.protocol.TopicAssignment;
 import com.pinterest.memq.commons.protocol.TopicConfig;
+import com.pinterest.memq.core.config.MemqConfig;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 import java.util.Arrays;
 import java.util.HashMap;
@@ -471,7 +473,9 @@ public class TestExpirationPartitionBalanceStrategyWithAssignmentFreeze {
     }
 
     private static BalanceStrategy getExpirationBalanceStrategyWithFreeze(long expirationTime) {
-        ExpirationPartitionBalanceStrategyWithAssignmentFreeze strategy = new ExpirationPartitionBalanceStrategyWithAssignmentFreeze();
+        MemqConfig mockMemqConfig = Mockito.mock(MemqConfig.class);
+        Mockito.when(mockMemqConfig.getOpenTsdbConfig()).thenReturn(null);
+        ExpirationPartitionBalanceStrategyWithAssignmentFreeze strategy = new ExpirationPartitionBalanceStrategyWithAssignmentFreeze(mockMemqConfig);
         strategy.setDefaultExpirationTime(expirationTime); // 500ms
         return strategy;
     }


### PR DESCRIPTION
The aim is to create a metrics reporter that will log errors occurring within the `ExpirationPartitionBalanceStrategyWithErrorHandling` class and its subclasses. This functionality is intended to help engineers monitor issues with the balancer and respond promptly by setting up alarms based on the reported data points.  