### PR TITLE
MemQ Server-Side Broker-Level Traffic Throttling

### DIFF
--- a/memq/src/main/java/com/pinterest/memq/core/config/NettyServerConfig.java
+++ b/memq/src/main/java/com/pinterest/memq/core/config/NettyServerConfig.java
@@ -23,9 +23,26 @@ public class NettyServerConfig {
   private short port = 9092;
   private int numEventLoopThreads = 8;
   private boolean enableEpoll = false;
-
+  private int maxBrokerInputTrafficMbPerSec = -1; // -1 means no traffic limit by default
+  private int brokerInputTrafficShapingCheckIntervalMs = 1000; // 1 second by default
   // SSL
   private SSLConfig sslConfig;
+
+  public int getMaxBrokerInputTrafficMbPerSec() {
+    return maxBrokerInputTrafficMbPerSec;
+  }
+
+  public void setMaxBrokerInputTrafficMbPerSec(int maxBrokerInputTrafficMbPerSec) {
+    this.maxBrokerInputTrafficMbPerSec = maxBrokerInputTrafficMbPerSec;
+  }
+
+  public int getBrokerInputTrafficShapingCheckIntervalMs() {
+      return brokerInputTrafficShapingCheckIntervalMs;
+  }
+
+  public void setBrokerInputTrafficShapingCheckIntervalMs(int brokerInputTrafficShapingCheckIntervalMs) {
+      this.brokerInputTrafficShapingCheckIntervalMs = brokerInputTrafficShapingCheckIntervalMs;
+  }
 
   public int getMaxFrameByteLength() {
     return maxFrameByteLength;

--- a/memq/src/main/java/com/pinterest/memq/core/rpc/BrokerTrafficShapingHandler.java
+++ b/memq/src/main/java/com/pinterest/memq/core/rpc/BrokerTrafficShapingHandler.java
@@ -1,0 +1,22 @@
+package com.pinterest.memq.core.rpc;
+
+import com.codahale.metrics.MetricRegistry;
+import io.netty.handler.traffic.GlobalTrafficShapingHandler;
+
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.logging.Logger;
+
+public class BrokerTrafficShapingHandler extends GlobalTrafficShapingHandler {
+
+    private static final Logger logger = Logger.getLogger(BrokerTrafficShapingHandler.class.getName());
+    private final MetricRegistry registry;
+
+    public BrokerTrafficShapingHandler(ScheduledExecutorService executor,
+                                       long writeLimit,
+                                       long readLimit,
+                                       long checkInterval,
+                                       MetricRegistry registry) {
+        super(executor, writeLimit, readLimit, checkInterval);
+        this.registry = registry;
+    }
+}


### PR DESCRIPTION
This change introduces server-side broker-level traffic-based throttling for the memq system. It relies on the `GlobalTrafficShapingHandler` from the Netty package. The modification encompasses three key areas:  
  
1. **Configuration Updates**:   
   - Two new configurations, `maxBrokerInputTrafficMbPerSec` and `brokerInputTrafficShapingCheckIntervalMs`, are added to `NettyServerConfig`. These configurations have default values and are initialized from the cluster configuration file.  
  
2. **Handler Creation**:  
   - A new class, `BrokerTrafficShapingHandler`, is created based on `GlobalTrafficShapingHandler`. Currently, this class does not include any additional logic, but future updates will introduce metrics and alarming capabilities.  
  
3. **Integration with MemqNettyServer**:  
   - The `BrokerTrafficShapingHandler` is integrated into `MemqNettyServer`. The handler is attached to each channel if the feature is enabled. Nonetheless, it requires initialization to be passed into each individual channel thread.  
  
### Testing  
  
The changes have been tested using a branch within Pinterest, ensuring their effectiveness and stability.  