### PR TITLE
Implementing Metrics Logic for BrokerTrafficShapingHandler

### DIFF
--- a/memq/src/main/java/com/pinterest/memq/core/config/NettyServerConfig.java
+++ b/memq/src/main/java/com/pinterest/memq/core/config/NettyServerConfig.java
@@ -25,8 +25,18 @@ public class NettyServerConfig {
   private boolean enableEpoll = false;
   private int maxBrokerInputTrafficMbPerSec = -1; // -1 means no traffic limit by default
   private int brokerInputTrafficShapingCheckIntervalMs = 1000; // 1 second by default
+  private int brokerInputTrafficShapingMetricsReportIntervalSec = 60; // 1 minute by default
   // SSL
   private SSLConfig sslConfig;
+
+  public int getBrokerInputTrafficShapingMetricsReportIntervalSec() {
+    return brokerInputTrafficShapingMetricsReportIntervalSec;
+  }
+
+  public void setBrokerInputTrafficShapingMetricsReportIntervalSec(
+      int brokerInputTrafficShapingMetricsReportIntervalSec) {
+      this.brokerInputTrafficShapingMetricsReportIntervalSec = brokerInputTrafficShapingMetricsReportIntervalSec;
+  }
 
   public int getMaxBrokerInputTrafficMbPerSec() {
     return maxBrokerInputTrafficMbPerSec;

--- a/memq/src/main/java/com/pinterest/memq/core/rpc/BrokerTrafficShapingHandler.java
+++ b/memq/src/main/java/com/pinterest/memq/core/rpc/BrokerTrafficShapingHandler.java
@@ -4,11 +4,14 @@ import com.codahale.metrics.MetricRegistry;
 import io.netty.handler.traffic.GlobalTrafficShapingHandler;
 
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 import java.util.logging.Logger;
 
 public class BrokerTrafficShapingHandler extends GlobalTrafficShapingHandler {
 
+    public static final String READ_LIMIT_METRIC_NAME = "broker.traffic.read.limit";
     private static final Logger logger = Logger.getLogger(BrokerTrafficShapingHandler.class.getName());
+    private static int metricsReportingIntervalSec = 60; // default 1 minute
     private final MetricRegistry registry;
 
     public BrokerTrafficShapingHandler(ScheduledExecutorService executor,
@@ -18,5 +21,35 @@ public class BrokerTrafficShapingHandler extends GlobalTrafficShapingHandler {
                                        MetricRegistry registry) {
         super(executor, writeLimit, readLimit, checkInterval);
         this.registry = registry;
+    }
+
+    public void setMetricsReportingIntervalSec(int intervalSec) {
+        metricsReportingIntervalSec = intervalSec;
+    }
+
+    public int getMetricsReportingIntervalSec() {
+        return metricsReportingIntervalSec;
+    }
+
+    /**
+     * Start periodic metrics reporting.
+     * Overriding channel methods to send metrics can cause performance issues.
+     * So we choose to send metrics in a separate thread periodically.
+     * @param executorService
+     */
+    public void startPeriodicMetricsReporting(ScheduledExecutorService executorService) {
+        logger.info(String.format("Starting periodic metrics reporting every %d seconds.",
+            metricsReportingIntervalSec));
+        Runnable reportTask = this::reportMetrics;
+        executorService.scheduleAtFixedRate(
+            reportTask, 0, metricsReportingIntervalSec, TimeUnit.SECONDS);
+    }
+
+    /**
+     * Report read limit metric to the registry.
+     */
+    public void reportMetrics() {
+        long readLimit = this.getReadLimit();
+        registry.gauge(READ_LIMIT_METRIC_NAME, () -> () -> readLimit);
     }
 }

--- a/memq/src/main/java/com/pinterest/memq/core/rpc/BrokerTrafficShapingHandler.java
+++ b/memq/src/main/java/com/pinterest/memq/core/rpc/BrokerTrafficShapingHandler.java
@@ -11,7 +11,7 @@ public class BrokerTrafficShapingHandler extends GlobalTrafficShapingHandler {
 
     public static final String READ_LIMIT_METRIC_NAME = "broker.traffic.read.limit";
     private static final Logger logger = Logger.getLogger(BrokerTrafficShapingHandler.class.getName());
-    private static int metricsReportingIntervalSec = 60; // default 1 minute
+    private int metricsReportingIntervalSec = 60; // default 1 minute
     private final MetricRegistry registry;
 
     public BrokerTrafficShapingHandler(ScheduledExecutorService executor,
@@ -23,21 +23,35 @@ public class BrokerTrafficShapingHandler extends GlobalTrafficShapingHandler {
         this.registry = registry;
     }
 
+    /**
+     * Set the interval for metrics reporting.
+     * If the interval is less than or equal to 0, metrics reporting is disabled.
+     * @param intervalSec
+     */
     public void setMetricsReportingIntervalSec(int intervalSec) {
         metricsReportingIntervalSec = intervalSec;
     }
 
+    /**
+     * Get the interval for metrics reporting.
+     * @return intervalSec
+     */
     public int getMetricsReportingIntervalSec() {
         return metricsReportingIntervalSec;
     }
 
     /**
-     * Start periodic metrics reporting.
+     * Start periodic metrics reporting. The interval is specified by metricsReportingIntervalSec.
+     * If the interval is less than or equal to 0, metrics reporting is disabled.
      * Overriding channel methods to send metrics can cause performance issues.
      * So we choose to send metrics in a separate thread periodically.
      * @param executorService
      */
     public void startPeriodicMetricsReporting(ScheduledExecutorService executorService) {
+        if (metricsReportingIntervalSec <= 0) {
+            logger.warning("Metrics reporting is disabled because the interval is less than or equal to 0.");
+            return;
+        }
         logger.info(String.format("Starting periodic metrics reporting every %d seconds.",
             metricsReportingIntervalSec));
         Runnable reportTask = this::reportMetrics;

--- a/memq/src/main/java/com/pinterest/memq/core/rpc/MemqNettyServer.java
+++ b/memq/src/main/java/com/pinterest/memq/core/rpc/MemqNettyServer.java
@@ -132,6 +132,8 @@ public class MemqNettyServer {
                 registry
       );
       if (isTrafficShapingEnabled) {
+        trafficShapingHandler.setMetricsReportingIntervalSec(
+            nettyServerConfig.getBrokerInputTrafficShapingMetricsReportIntervalSec());
         trafficShapingHandler.startPeriodicMetricsReporting(childGroup);
       }
 

--- a/memq/src/main/java/com/pinterest/memq/core/rpc/MemqNettyServer.java
+++ b/memq/src/main/java/com/pinterest/memq/core/rpc/MemqNettyServer.java
@@ -17,6 +17,9 @@ package com.pinterest.memq.core.rpc;
 
 import java.net.UnknownHostException;
 import java.nio.ByteOrder;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
@@ -69,6 +72,10 @@ public class MemqNettyServer {
   public static final String SSL_HANDLER_NAME = "ssl";
 
   private static final Logger logger = Logger.getLogger(MemqNettyServer.class.getName());
+  // Include the metric names that are dependent on the Netty server but are not initialized in this class.
+  private static final List<String> DEPENDENCY_METRIC_NAMES = Arrays.asList(
+      BrokerTrafficShapingHandler.READ_LIMIT_METRIC_NAME
+  );
   private EventLoopGroup childGroup;
   private EventLoopGroup parentGroup;
   private ChannelFuture serverChannelFuture;
@@ -124,6 +131,9 @@ public class MemqNettyServer {
                 checkIntervalMs,
                 registry
       );
+      if (isTrafficShapingEnabled) {
+        trafficShapingHandler.startPeriodicMetricsReporting(childGroup);
+      }
 
       if (useEpoll) {
         serverBootstrap.channel(EpollServerSocketChannel.class);
@@ -194,7 +204,9 @@ public class MemqNettyServer {
 
     if (client != null) {
       String localHostname = MiscUtils.getHostname();
-      for (String metricName : registry.getNames()) {
+      List<String> metricsNames = new ArrayList<>(registry.getNames());
+      metricsNames.addAll(DEPENDENCY_METRIC_NAMES);
+      for (String metricName : metricsNames) {
         ScheduledReporter reporter = OpenTSDBReporter.createReporter("netty", registry, metricName,
             (String name, Metric metric) -> true, TimeUnit.SECONDS, TimeUnit.SECONDS, client,
             localHostname);


### PR DESCRIPTION
This PR introduces logic for the `BrokerTrafficShapingHandler` to periodically send metrics. This enables engineers to set up monitoring or alarms to determine whether throttling logic is enabled in the cluster or if the traffic is being throttled. The class now includes a parameter, `metricsReportingIntervalSec`, which specifies the frequency of reporting these metrics, with a default interval of 1 minute. 
  
### Key Changes  
  
- **Metrics Integration**:  
  - Metrics are integrated into the Netty metrics reporter. In the `MemqNettyServer` class, there is logic that allows the reporter to register metrics from various dependencies, including this handler.  
  
- **Performance Considerations**:  
  - Initially, we considered adding metrics by overriding the `channelRead` or `doAccounting` methods. However, due to Memq's high traffic volume, overriding these methods could degrade performance. We determined that periodic metric reporting is more efficient and meets our requirements without impacting performance.  
  
### Testing  
  
The changes have been tested within Pinterest via branch deployment, and no issues were observed during testing.  