### PR TITLE
Make MemqConsumer compatible with FlinkSQL 1.18; bump version to 1.0.2-SNAPSHOT

### DIFF
--- a/deploy/pom.xml
+++ b/deploy/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>com.pinterest.memq</groupId>
 		<artifactId>memq-parent</artifactId>
-		<version>1.0.1</version>
+		<version>1.0.2-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<artifactId>memq-deploy</artifactId>

--- a/memq-client-all/pom.xml
+++ b/memq-client-all/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>com.pinterest.memq</groupId>
 		<artifactId>memq-parent</artifactId>
-		<version>1.0.1</version>
+		<version>1.0.2-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<artifactId>memq-client-all</artifactId>
@@ -48,7 +48,7 @@
 		<dependency>
 			<groupId>com.pinterest.memq</groupId>
 			<artifactId>memq-client</artifactId>
-			<version>1.0.1</version>
+			<version>1.0.2-SNAPSHOT</version>
 		</dependency>
 	</dependencies>
 	<build>

--- a/memq-client/pom.xml
+++ b/memq-client/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>com.pinterest.memq</groupId>
 		<artifactId>memq-parent</artifactId>
-		<version>1.0.1</version>
+		<version>1.0.2-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<artifactId>memq-client</artifactId>

--- a/memq-client/src/main/java/com/pinterest/memq/client/commons/MemqMessageHeader.java
+++ b/memq-client/src/main/java/com/pinterest/memq/client/commons/MemqMessageHeader.java
@@ -120,38 +120,36 @@ public class MemqMessageHeader {
   public void writeHeader(final ByteBuf buffer) {
     boolean useTaskRequest = taskRequest != null;
     CRC32 crc = new CRC32();
-    ByteBuf wrap = buffer.duplicate();
-    wrap.writerIndex(0);
-    wrap.writeShort(getHeaderLength()); // 2bytes
+
+    // Use absolute-index set methods instead of duplicate() + relative write methods,
+    // because buffer may be a PooledSlicedByteBuf whose duplicate() translates indices
+    // to the parent buffer's coordinate space, breaking writerIndex(0).
+    int idx = 0;
+    buffer.setShort(idx, getHeaderLength()); idx += 2;
     if (useTaskRequest) {
-      wrap.writeShort(taskRequest.getVersion()); // 2bytes
+      buffer.setShort(idx, taskRequest.getVersion()); idx += 2;
     } else {
-      wrap.writeShort(request.getVersion()); // 2bytes
+      buffer.setShort(idx, request.getVersion()); idx += 2;
     }
-    // add extra stuff
     byte[] extraHeaderContent = getExtraHeaderContent();
-    wrap.writeShort((short) extraHeaderContent.length);// 2bytes
-    wrap.writeBytes(extraHeaderContent);
+    buffer.setShort(idx, (short) extraHeaderContent.length); idx += 2;
+    buffer.setBytes(idx, extraHeaderContent); idx += extraHeaderContent.length;
 
-    ByteBuf tmp = buffer.duplicate();
-    tmp.readerIndex(getHeaderLength());
-    ByteBuf slice = tmp.slice();
-    crc.update(slice.nioBuffer());
+    ByteBuf bodySlice = buffer.slice(getHeaderLength(), buffer.writerIndex() - getHeaderLength());
+    crc.update(bodySlice.nioBuffer());
     int checkSum = (int) crc.getValue();
-    // write crc checksum of the body
-    wrap.writeInt(checkSum);// 4bytes
-    // compression scheme encoding
+
+    buffer.setInt(idx, checkSum); idx += 4;
     if (useTaskRequest) {
-      wrap.writeByte(taskRequest.getCompression().id);// 1byte
-      wrap.writeInt(taskRequest.getLogmessageCount()); // 4bytes
+      buffer.setByte(idx, taskRequest.getCompression().id); idx += 1;
+      buffer.setInt(idx, taskRequest.getLogmessageCount()); idx += 4;
     } else {
-      wrap.writeByte(request.getCompression().id);// 1byte
-      wrap.writeInt(request.getMessageCount()); // 4bytes
+      buffer.setByte(idx, request.getCompression().id); idx += 1;
+      buffer.setInt(idx, request.getMessageCount()); idx += 4;
     }
 
-    // write the length of remaining bytes
     int payloadLength = buffer.readableBytes() - getHeaderLength();
-    wrap.writeInt(payloadLength); // 4bytes
+    buffer.setInt(idx, payloadLength); idx += 4;
   }
 
   private byte[] getExtraHeaderContent() {

--- a/memq-client/src/main/java/com/pinterest/memq/client/commons/MemqMessageHeader.java
+++ b/memq-client/src/main/java/com/pinterest/memq/client/commons/MemqMessageHeader.java
@@ -125,31 +125,31 @@ public class MemqMessageHeader {
     // because buffer may be a PooledSlicedByteBuf whose duplicate() translates indices
     // to the parent buffer's coordinate space, breaking writerIndex(0).
     int idx = 0;
-    buffer.setShort(idx, getHeaderLength()); idx += 2;
+    buffer.setShort(idx, getHeaderLength()); idx += Short.BYTES;
     if (useTaskRequest) {
-      buffer.setShort(idx, taskRequest.getVersion()); idx += 2;
+      buffer.setShort(idx, taskRequest.getVersion()); idx += Short.BYTES;
     } else {
-      buffer.setShort(idx, request.getVersion()); idx += 2;
+      buffer.setShort(idx, request.getVersion()); idx += Short.BYTES;
     }
     byte[] extraHeaderContent = getExtraHeaderContent();
-    buffer.setShort(idx, (short) extraHeaderContent.length); idx += 2;
+    buffer.setShort(idx, (short) extraHeaderContent.length); idx += Short.BYTES;
     buffer.setBytes(idx, extraHeaderContent); idx += extraHeaderContent.length;
 
     ByteBuf bodySlice = buffer.slice(getHeaderLength(), buffer.writerIndex() - getHeaderLength());
     crc.update(bodySlice.nioBuffer());
     int checkSum = (int) crc.getValue();
 
-    buffer.setInt(idx, checkSum); idx += 4;
+    buffer.setInt(idx, checkSum); idx += Integer.BYTES;
     if (useTaskRequest) {
-      buffer.setByte(idx, taskRequest.getCompression().id); idx += 1;
-      buffer.setInt(idx, taskRequest.getLogmessageCount()); idx += 4;
+      buffer.setByte(idx, taskRequest.getCompression().id); idx += Byte.BYTES;
+      buffer.setInt(idx, taskRequest.getLogmessageCount()); idx += Integer.BYTES;
     } else {
-      buffer.setByte(idx, request.getCompression().id); idx += 1;
-      buffer.setInt(idx, request.getMessageCount()); idx += 4;
+      buffer.setByte(idx, request.getCompression().id); idx += Byte.BYTES;
+      buffer.setInt(idx, request.getMessageCount()); idx += Integer.BYTES;
     }
 
     int payloadLength = buffer.readableBytes() - getHeaderLength();
-    buffer.setInt(idx, payloadLength); idx += 4;
+    buffer.setInt(idx, payloadLength); idx += Integer.BYTES;
   }
 
   private byte[] getExtraHeaderContent() {

--- a/memq-client/src/main/java/com/pinterest/memq/client/commons2/MemqCommonClient.java
+++ b/memq-client/src/main/java/com/pinterest/memq/client/commons2/MemqCommonClient.java
@@ -270,7 +270,7 @@ public class MemqCommonClient implements Closeable {
     return getTopicMetadata(topic, connectTimeout);
   }
 
-  public Collection<String> getTopics() throws ExecutionException, InterruptedException,
+  public Collection<TopicMetadata> getTopics() throws ExecutionException, InterruptedException,
                                                TimeoutException {
     Future<ResponsePacket> response = sendRequestPacketAndReturnResponseFuture(
         new RequestPacket(RequestType.PROTOCOL_VERSION, ThreadLocalRandom.current().nextLong(),
@@ -278,12 +278,8 @@ public class MemqCommonClient implements Closeable {
         "", connectTimeout);
     ResponsePacket responsePacket = response.get(connectTimeout, TimeUnit.MILLISECONDS);
     TopicMetadataResponsePacket resp = (TopicMetadataResponsePacket) responsePacket.getPacket();
-    List<String> topicNames = new ArrayList<>();
-    for (TopicMetadata md : resp.getMetadataList()) {
-      topicNames.add(md.getTopicName());
-    }
     writeEndpoints = Collections.emptyList();
-    return topicNames;
+    return resp.getMetadataList();
   }
 
   public synchronized void reconnect(String topic, boolean isConsumer) throws Exception {

--- a/memq-client/src/main/java/com/pinterest/memq/client/commons2/MemqCommonClient.java
+++ b/memq-client/src/main/java/com/pinterest/memq/client/commons2/MemqCommonClient.java
@@ -270,6 +270,13 @@ public class MemqCommonClient implements Closeable {
     return getTopicMetadata(topic, connectTimeout);
   }
 
+  /**
+   * Get all topics from the MemQ cluster.
+   * @return a collection of TopicMetadata objects
+   * @throws ExecutionException
+   * @throws InterruptedException
+   * @throws TimeoutException
+   */
   public Collection<TopicMetadata> getTopics() throws ExecutionException, InterruptedException,
                                                TimeoutException {
     Future<ResponsePacket> response = sendRequestPacketAndReturnResponseFuture(

--- a/memq-client/src/main/java/com/pinterest/memq/client/commons2/MemqCommonClient.java
+++ b/memq-client/src/main/java/com/pinterest/memq/client/commons2/MemqCommonClient.java
@@ -18,6 +18,7 @@ package com.pinterest.memq.client.commons2;
 import static com.pinterest.memq.client.commons2.Endpoint.DEFAULT_LOCALITY;
 
 import java.io.Closeable;
+import java.util.Collection;
 import java.io.File;
 import java.io.IOException;
 import java.net.ConnectException;
@@ -267,6 +268,22 @@ public class MemqCommonClient implements Closeable {
                                                       ExecutionException, InterruptedException,
                                                       TimeoutException {
     return getTopicMetadata(topic, connectTimeout);
+  }
+
+  public Collection<String> getTopics() throws ExecutionException, InterruptedException,
+                                               TimeoutException {
+    Future<ResponsePacket> response = sendRequestPacketAndReturnResponseFuture(
+        new RequestPacket(RequestType.PROTOCOL_VERSION, ThreadLocalRandom.current().nextLong(),
+            RequestType.TOPIC_METADATA, new TopicMetadataRequestPacket(Collections.emptyList())),
+        "", connectTimeout);
+    ResponsePacket responsePacket = response.get(connectTimeout, TimeUnit.MILLISECONDS);
+    TopicMetadataResponsePacket resp = (TopicMetadataResponsePacket) responsePacket.getPacket();
+    List<String> topicNames = new ArrayList<>();
+    for (TopicMetadata md : resp.getMetadataList()) {
+      topicNames.add(md.getTopicName());
+    }
+    writeEndpoints = Collections.emptyList();
+    return topicNames;
   }
 
   public synchronized void reconnect(String topic, boolean isConsumer) throws Exception {

--- a/memq-client/src/main/java/com/pinterest/memq/client/consumer/MemqConsumer.java
+++ b/memq-client/src/main/java/com/pinterest/memq/client/consumer/MemqConsumer.java
@@ -61,7 +61,6 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeoutException;
-import java.util.concurrent.atomic.AtomicLong;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
@@ -70,7 +69,6 @@ import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.mutable.MutableInt;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
-import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
 
@@ -120,6 +118,9 @@ public final class MemqConsumer<K, V> implements Closeable {
   private static final Logger logger = Logger.getLogger(MemqConsumer.class.getCanonicalName());
 
   public static final String METRICS_PREFIX = "memq.consumer";
+  public static final String BYTES_CONSUMED_TOTAL_METRIC = "bytes.consumed.total";
+  public static final String NOTIFICATION_RECORDS_LAG_MAX_METRIC = "notification.records.lag.max";
+  
   private final MemqLogMessage<K, V> EMPTY_MESSAGE = new MemqLogMessage<>(null, null, null, null, true);
 
   public MemqLogMessageIterator<K, V> EMPTY_ITERATOR = new MemqLogMessageIterator<K, V>() {
@@ -151,7 +152,6 @@ public final class MemqConsumer<K, V> implements Closeable {
   private volatile boolean closed = false;
 
   // metrics
-  private final AtomicLong bytesConsumedTotal = new AtomicLong(0);
   private MetricRegistry metricRegistry;
   private File bufferFile;
   private String cluster;
@@ -263,6 +263,7 @@ public final class MemqConsumer<K, V> implements Closeable {
     if (metricRegistry != null) {
       iteratorExceptionCounter = metricRegistry.counter("iterator.exception");
       loadBatchExceptionCounter = metricRegistry.counter("loading.exception");
+      metricRegistry.counter(BYTES_CONSUMED_TOTAL_METRIC);
 
       metricRegistry.gauge("netty.direct.memory.used",
               () -> () -> PooledByteBufAllocator.DEFAULT.metric().usedDirectMemory());
@@ -346,7 +347,9 @@ public final class MemqConsumer<K, V> implements Closeable {
         newStream = new ByteArrayInputStream(out.toByteArray());
         out.close();
       }
-      bytesConsumedTotal.addAndGet(bytesCopied);
+      if (metricRegistry != null) {
+        metricRegistry.counter(BYTES_CONSUMED_TOTAL_METRIC).inc(bytesCopied);
+      }
       return new DataInputStream(newStream);
     } finally {
       try {
@@ -415,6 +418,7 @@ public final class MemqConsumer<K, V> implements Closeable {
           .get(NOTIFICATION_SOURCE_PROPS_KEY);
       this.notificationSource = new KafkaNotificationSource(notificationSourceProperties);
       notificationSource.setParentConsumer(this);
+      registerNotificationLagGauge();
     } catch (Exception e) {
       logger.log(Level.SEVERE, "Failed to initialize notification source", e);
       throw e;
@@ -440,6 +444,27 @@ public final class MemqConsumer<K, V> implements Closeable {
     if (notificationSource == null) {
       notificationSource = new KafkaNotificationSource(notificationSourceProps);
       notificationSource.setParentConsumer(this);
+      registerNotificationLagGauge();
+    }
+  }
+
+  private void registerNotificationLagGauge() {
+    if (metricRegistry != null && notificationSource != null) {
+      metricRegistry.gauge(NOTIFICATION_RECORDS_LAG_MAX_METRIC, () -> () -> {
+        Object raw = notificationSource.getRawObject();
+        if (raw instanceof Consumer) {
+          for (Map.Entry<org.apache.kafka.common.MetricName, ? extends org.apache.kafka.common.Metric> entry
+              : ((Consumer<?, ?>) raw).metrics().entrySet()) {
+            if ("records-lag-max".equals(entry.getKey().name())) {
+              Object value = entry.getValue().metricValue();
+              if (value instanceof Number) {
+                return ((Number) value).doubleValue();
+              }
+            }
+          }
+        }
+        return Double.NaN;
+      });
     }
   }
 
@@ -736,25 +761,11 @@ public final class MemqConsumer<K, V> implements Closeable {
 
   public void setNotificationSource(KafkaNotificationSource notificationSource) {
     this.notificationSource = notificationSource;
+    registerNotificationLagGauge();
   }
 
   public MetricRegistry getMetricRegistry() {
     return metricRegistry;
-  }
-
-  public long getBytesConsumedTotal() {
-    return bytesConsumedTotal.get();
-  }
-
-  public Map<MetricName, ? extends org.apache.kafka.common.Metric> getNotificationConsumerMetrics() {
-    if (notificationSource == null) {
-      return Collections.emptyMap();
-    }
-    Object raw = notificationSource.getRawObject();
-    if (raw instanceof Consumer) {
-      return ((Consumer<?, ?>) raw).metrics();
-    }
-    return Collections.emptyMap();
   }
 
   public String getTopicName() {

--- a/memq-client/src/main/java/com/pinterest/memq/client/consumer/MemqConsumer.java
+++ b/memq-client/src/main/java/com/pinterest/memq/client/consumer/MemqConsumer.java
@@ -471,6 +471,11 @@ public final class MemqConsumer<K, V> implements Closeable {
     return notificationSource.getLatestOffsets(partitions);
   }
 
+  /**
+   * Get all topics from the MemQ cluster. This method is only available for non-direct consumers.
+   * @return a collection of TopicMetadata objects
+   * @throws Exception
+   */
   public Collection<TopicMetadata> getTopics() throws Exception {
     if (client == null) {
       throw new IllegalStateException("getTopics() requires a non-direct consumer with bootstrap servers");

--- a/memq-client/src/main/java/com/pinterest/memq/client/consumer/MemqConsumer.java
+++ b/memq-client/src/main/java/com/pinterest/memq/client/consumer/MemqConsumer.java
@@ -173,6 +173,8 @@ public final class MemqConsumer<K, V> implements Closeable {
     this.isDirectBuffer = Boolean.parseBoolean(props.getProperty(USE_DIRECT_BUFFER_KEY, "false"));
     if (isDirectBuffer) {
       logger.info("Using direct buffer");
+    } else {
+      logger.info("Using heap buffer");
     }
 
     String clientId = props.getProperty(CLIENT_ID, UUID.randomUUID().toString());
@@ -324,10 +326,15 @@ public final class MemqConsumer<K, V> implements Closeable {
       } else if (isDirectBuffer) {
         ByteBuf byteBuf = PooledByteBufAllocator.DEFAULT
             .directBuffer(storageHandler.getBatchSizeFromNotification(nextNotificationToProcess));
-        ByteBufOutputStream out = new ByteBufOutputStream(byteBuf);
-        IOUtils.copy(stream, out);
-        newStream = new ByteBufInputStream(byteBuf, true);
-        out.close();
+        try {
+          ByteBufOutputStream out = new ByteBufOutputStream(byteBuf);
+          IOUtils.copy(stream, out);
+          newStream = new ByteBufInputStream(byteBuf, true);
+          out.close();
+        } catch (Exception e) {
+          byteBuf.release();
+          throw e;
+        }
       } else {
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         IOUtils.copy(stream, out);

--- a/memq-client/src/main/java/com/pinterest/memq/client/consumer/MemqConsumer.java
+++ b/memq-client/src/main/java/com/pinterest/memq/client/consumer/MemqConsumer.java
@@ -471,7 +471,7 @@ public final class MemqConsumer<K, V> implements Closeable {
     return notificationSource.getLatestOffsets(partitions);
   }
 
-  public Collection<String> getTopics() throws Exception {
+  public Collection<TopicMetadata> getTopics() throws Exception {
     if (client == null) {
       throw new IllegalStateException("getTopics() requires a non-direct consumer with bootstrap servers");
     }

--- a/memq-client/src/main/java/com/pinterest/memq/client/consumer/MemqConsumer.java
+++ b/memq-client/src/main/java/com/pinterest/memq/client/consumer/MemqConsumer.java
@@ -171,6 +171,9 @@ public final class MemqConsumer<K, V> implements Closeable {
     this.isBufferToFile = Boolean
         .parseBoolean(props.getProperty(BUFFER_TO_FILE_CONFIG_KEY, "false"));
     this.isDirectBuffer = Boolean.parseBoolean(props.getProperty(USE_DIRECT_BUFFER_KEY, "false"));
+    if (isDirectBuffer) {
+      logger.info("Using direct buffer");
+    }
 
     String clientId = props.getProperty(CLIENT_ID, UUID.randomUUID().toString());
     checkAndConfigureTmpFileBuffering(props, clientId);
@@ -255,12 +258,10 @@ public final class MemqConsumer<K, V> implements Closeable {
       iteratorExceptionCounter = metricRegistry.counter("iterator.exception");
       loadBatchExceptionCounter = metricRegistry.counter("loading.exception");
 
-      if (isDirectBuffer) {
-        metricRegistry.gauge("netty.direct.memory.used",
-            () -> () -> PooledByteBufAllocator.DEFAULT.metric().usedDirectMemory());
-        metricRegistry.gauge("netty.heap.memory.used",
-            () -> () -> PooledByteBufAllocator.DEFAULT.metric().usedHeapMemory());
-      }
+      metricRegistry.gauge("netty.direct.memory.used",
+              () -> () -> PooledByteBufAllocator.DEFAULT.metric().usedDirectMemory());
+      metricRegistry.gauge("netty.heap.memory.used",
+              () -> () -> PooledByteBufAllocator.DEFAULT.metric().usedHeapMemory());
     }
   }
 

--- a/memq-client/src/main/java/com/pinterest/memq/client/consumer/MemqConsumer.java
+++ b/memq-client/src/main/java/com/pinterest/memq/client/consumer/MemqConsumer.java
@@ -73,6 +73,7 @@ import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
 
 import com.codahale.metrics.Counter;
+import com.codahale.metrics.MetricFilter;
 import com.codahale.metrics.MetricRegistry;
 import com.google.common.collect.ImmutableMap;
 import com.google.gson.JsonObject;
@@ -536,6 +537,9 @@ public final class MemqConsumer<K, V> implements Closeable {
   @Override
   public void close() throws IOException {
     closed = true;
+    if (metricRegistry != null) {
+      metricRegistry.removeMatching(MetricFilter.ALL);
+    }
     notificationQueue.clear();
     if (notificationSource != null) {
       notificationSource.close();

--- a/memq-client/src/main/java/com/pinterest/memq/client/consumer/MemqConsumer.java
+++ b/memq-client/src/main/java/com/pinterest/memq/client/consumer/MemqConsumer.java
@@ -471,6 +471,13 @@ public final class MemqConsumer<K, V> implements Closeable {
     return notificationSource.getLatestOffsets(partitions);
   }
 
+  public Collection<String> getTopics() throws Exception {
+    if (client == null) {
+      throw new IllegalStateException("getTopics() requires a non-direct consumer with bootstrap servers");
+    }
+    return client.getTopics();
+  }
+
   public long position(int partition) {
     return notificationSource.position(partition);
   }

--- a/memq-client/src/main/java/com/pinterest/memq/client/consumer/MemqConsumer.java
+++ b/memq-client/src/main/java/com/pinterest/memq/client/consumer/MemqConsumer.java
@@ -61,13 +61,16 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.mutable.MutableInt;
+import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
 
@@ -148,6 +151,7 @@ public final class MemqConsumer<K, V> implements Closeable {
   private volatile boolean closed = false;
 
   // metrics
+  private final AtomicLong bytesConsumedTotal = new AtomicLong(0);
   private MetricRegistry metricRegistry;
   private File bufferFile;
   private String cluster;
@@ -320,15 +324,16 @@ public final class MemqConsumer<K, V> implements Closeable {
     InputStream stream = fetchBatchStreamForNotification(nextNotificationToProcess);
     InputStream newStream;
     try {
+      long bytesCopied;
       if (isBufferToFile) {
-        IOUtils.copy(stream, new FileOutputStream(bufferFile));
+        bytesCopied = IOUtils.copy(stream, new FileOutputStream(bufferFile));
         newStream = new FileInputStream(bufferFile);
       } else if (isDirectBuffer) {
         ByteBuf byteBuf = PooledByteBufAllocator.DEFAULT
             .directBuffer(storageHandler.getBatchSizeFromNotification(nextNotificationToProcess));
         try {
           ByteBufOutputStream out = new ByteBufOutputStream(byteBuf);
-          IOUtils.copy(stream, out);
+          bytesCopied = IOUtils.copy(stream, out);
           newStream = new ByteBufInputStream(byteBuf, true);
           out.close();
         } catch (Exception e) {
@@ -337,10 +342,11 @@ public final class MemqConsumer<K, V> implements Closeable {
         }
       } else {
         ByteArrayOutputStream out = new ByteArrayOutputStream();
-        IOUtils.copy(stream, out);
+        bytesCopied = IOUtils.copy(stream, out);
         newStream = new ByteArrayInputStream(out.toByteArray());
         out.close();
       }
+      bytesConsumedTotal.addAndGet(bytesCopied);
       return new DataInputStream(newStream);
     } finally {
       try {
@@ -734,6 +740,21 @@ public final class MemqConsumer<K, V> implements Closeable {
 
   public MetricRegistry getMetricRegistry() {
     return metricRegistry;
+  }
+
+  public long getBytesConsumedTotal() {
+    return bytesConsumedTotal.get();
+  }
+
+  public Map<MetricName, ? extends org.apache.kafka.common.Metric> getNotificationConsumerMetrics() {
+    if (notificationSource == null) {
+      return Collections.emptyMap();
+    }
+    Object raw = notificationSource.getRawObject();
+    if (raw instanceof Consumer) {
+      return ((Consumer<?, ?>) raw).metrics();
+    }
+    return Collections.emptyMap();
   }
 
   public String getTopicName() {

--- a/memq-client/src/main/java/com/pinterest/memq/commons/storage/s3/reader/client/ReactorNettyRequestClient.java
+++ b/memq-client/src/main/java/com/pinterest/memq/commons/storage/s3/reader/client/ReactorNettyRequestClient.java
@@ -27,6 +27,8 @@ import com.codahale.metrics.MetricRegistry;
 import io.netty.handler.ssl.SslClosedEngineException;
 import io.netty.handler.timeout.ReadTimeoutException;
 import reactor.netty.http.client.HttpClient;
+import reactor.netty.resources.ConnectionProvider;
+import reactor.netty.resources.LoopResources;
 import reactor.util.retry.RetrySpec;
 import software.amazon.awssdk.http.SdkHttpFullRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
@@ -55,14 +57,20 @@ public class ReactorNettyRequestClient implements RequestClient {
   public static final String READ_TIMEOUT_MS = "readTimeoutMs";
   public static final String RESPONSE_TIMEOUT_MS = "responseTimeoutMs";
   public static final String MAX_RETRIES = "maxRetries";
+  public static final String EVENT_LOOP_THREADS = "eventLoopThreads";
+  public static final String MAX_CONNECTIONS = "maxConnections";
   private static final Logger logger = LoggerFactory.getLogger(ReactorNettyRequestClient.class);
 
   private static final long DEFAULT_READ_TIMEOUT_MS = 10000;
+  private static final int DEFAULT_EVENT_LOOP_THREADS = 2;
+  private static final int DEFAULT_MAX_CONNECTIONS = 64;
 
   private final S3Presigner presigner;
   private final MetricRegistry metricRegistry;
 
   private HttpClient client;
+  private LoopResources loopResources;
+  private ConnectionProvider connectionProvider;
   private int maxRetries = 4;
   private Duration readTimeoutDuration;
   private Duration responseTimeoutDuration;
@@ -87,15 +95,28 @@ public class ReactorNettyRequestClient implements RequestClient {
     if (properties.containsKey(RESPONSE_TIMEOUT_MS)) {
       responseTimeoutDuration = Duration.ofMillis(Long.parseLong(properties.getProperty(RESPONSE_TIMEOUT_MS)));
     } else {
-      // default to max number of attempts times read timeout plus a small buffer to avoid competing with read timeouts
       responseTimeoutDuration = readTimeoutDuration.multipliedBy(maxRetries + 1).plusMillis(100);
     }
+
+    int eventLoopThreads = Integer.parseInt(
+        properties.getProperty(EVENT_LOOP_THREADS, String.valueOf(DEFAULT_EVENT_LOOP_THREADS)));
+    int maxConns = Integer.parseInt(
+        properties.getProperty(MAX_CONNECTIONS, String.valueOf(DEFAULT_MAX_CONNECTIONS)));
+
+    this.loopResources = LoopResources.create("memq-s3", eventLoopThreads, true);
+    this.connectionProvider = ConnectionProvider.builder("memq-s3")
+        .maxConnections(maxConns)
+        .build();
+
+    logger.info("Initialized ReactorNettyRequestClient with {} event loop threads and {} max connections",
+        eventLoopThreads, maxConns);
 
     this.client = createHttpClient();
   }
 
   private HttpClient createHttpClient() {
-    return HttpClient.create()
+    return HttpClient.create(connectionProvider)
+        .runOn(loopResources)
         .option(ChannelOption.SO_SNDBUF, 4 * 1024 * 1024)
         .option(ChannelOption.SO_LINGER, 0)
         .responseTimeout(readTimeoutDuration)
@@ -228,5 +249,19 @@ public class ReactorNettyRequestClient implements RequestClient {
   @Override
   public void close() throws IOException {
     presigner.close();
+    try {
+      if (connectionProvider != null) {
+        connectionProvider.disposeLater().block(Duration.ofSeconds(5));
+      }
+    } catch (Exception e) {
+      logger.warn("Error disposing connection provider", e);
+    }
+    try {
+      if (loopResources != null) {
+        loopResources.disposeLater().block(Duration.ofSeconds(5));
+      }
+    } catch (Exception e) {
+      logger.warn("Error disposing loop resources", e);
+    }
   }
 }

--- a/memq-client/src/test/java/com/pinterest/memq/client/commons/TestMemqMessageHeader.java
+++ b/memq-client/src/test/java/com/pinterest/memq/client/commons/TestMemqMessageHeader.java
@@ -1,0 +1,372 @@
+/**
+ * Copyright 2022 Pinterest, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.pinterest.memq.client.commons;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.zip.CRC32;
+
+import org.junit.Test;
+
+import com.pinterest.memq.client.producer.MemqWriteResult;
+import com.pinterest.memq.client.producer.TaskRequest;
+import com.pinterest.memq.client.producer2.Request;
+import com.pinterest.memq.core.utils.MemqUtils;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufOutputStream;
+import io.netty.buffer.PooledByteBufAllocator;
+import io.netty.buffer.Unpooled;
+
+public class TestMemqMessageHeader {
+
+  /**
+   * Verify that writeHeader via TaskRequest writes each field at the correct
+   * absolute offset and that the final idx equals getHeaderLength().
+   */
+  @Test
+  public void testWriteHeaderIdxPositionsViaTaskRequest() throws Exception {
+    int logMessageCount = 7;
+    Compression compression = Compression.GZIP;
+    StubTaskRequest tr = new StubTaskRequest("testtopic", 42, 20000);
+    tr.setCompressionForTest(compression);
+    for (int i = 0; i < logMessageCount; i++) {
+      tr.incrementLogMessageCountForTest();
+    }
+
+    byte[] payload = "hello world payload".getBytes();
+    short headerLength = MemqMessageHeader.getHeaderLength();
+    ByteBuf buffer = Unpooled.buffer(headerLength + payload.length);
+    buffer.writerIndex(headerLength);
+    buffer.writeBytes(payload);
+
+    MemqMessageHeader header = new MemqMessageHeader(tr);
+    header.writeHeader(buffer);
+
+    int expectedExtraHeaderLen = MemqUtils.HOST_IPV4_ADDRESS.length + 1 + 8 + 8;
+
+    CRC32 expectedCrc = new CRC32();
+    ByteBuf bodySlice = buffer.slice(headerLength, payload.length);
+    expectedCrc.update(bodySlice.nioBuffer());
+    int expectedChecksum = (int) expectedCrc.getValue();
+
+    int idx = 0;
+    assertEquals("headerLength at offset 0", headerLength, buffer.getShort(idx));
+    idx += 2;
+    assertEquals("version at offset 2", tr.getVersion(), buffer.getShort(idx));
+    idx += 2;
+    assertEquals("extraHeaderContentLength at offset 4", expectedExtraHeaderLen, buffer.getShort(idx));
+    idx += 2;
+
+    byte hostAddrLen = buffer.getByte(idx);
+    assertEquals("host address length", MemqUtils.HOST_IPV4_ADDRESS.length, hostAddrLen);
+    idx += 1;
+    byte[] hostAddr = new byte[hostAddrLen];
+    buffer.getBytes(idx, hostAddr);
+    assertArrayEquals("host address bytes", MemqUtils.HOST_IPV4_ADDRESS, hostAddr);
+    idx += hostAddrLen;
+    assertEquals("producer epoch", tr.getEpoch(), buffer.getLong(idx));
+    idx += 8;
+    assertEquals("producer request id (clientRequestId)", tr.getId(), buffer.getLong(idx));
+    idx += 8;
+
+    assertEquals("crc checksum", expectedChecksum, buffer.getInt(idx));
+    idx += 4;
+    assertEquals("compression id", compression.id, buffer.getByte(idx));
+    idx += 1;
+    assertEquals("logmessage count", logMessageCount, buffer.getInt(idx));
+    idx += 4;
+    int expectedPayloadLength = buffer.readableBytes() - headerLength;
+    assertEquals("payload length", expectedPayloadLength, buffer.getInt(idx));
+    idx += 4;
+
+    assertEquals("final idx must equal headerLength", headerLength, idx);
+
+    buffer.release();
+  }
+
+  /**
+   * Verify that writeHeader via Request (producer2 path) writes each field
+   * at the correct absolute offset and that the final idx equals getHeaderLength().
+   */
+  @Test
+  public void testWriteHeaderIdxPositionsViaRequest() throws Exception {
+    int messageCount = 3;
+    Compression compression = Compression.ZSTD;
+    short expectedVersion = 1_0_0;
+    long epoch = 12345L;
+    int clientRequestId = 99;
+
+    Request mockRequest = mock(Request.class);
+    when(mockRequest.getVersion()).thenReturn(expectedVersion);
+    when(mockRequest.getCompression()).thenReturn(compression);
+    when(mockRequest.getMessageCount()).thenReturn(messageCount);
+    when(mockRequest.getEpoch()).thenReturn(epoch);
+    when(mockRequest.getClientRequestId()).thenReturn(clientRequestId);
+
+    byte[] payload = "some payload bytes".getBytes();
+    short headerLength = MemqMessageHeader.getHeaderLength();
+    ByteBuf buffer = Unpooled.buffer(headerLength + payload.length);
+    buffer.writerIndex(headerLength);
+    buffer.writeBytes(payload);
+
+    MemqMessageHeader header = new MemqMessageHeader(mockRequest);
+    header.writeHeader(buffer);
+
+    int expectedExtraHeaderLen = MemqUtils.HOST_IPV4_ADDRESS.length + 1 + 8 + 8;
+
+    CRC32 expectedCrc = new CRC32();
+    ByteBuf bodySlice = buffer.slice(headerLength, payload.length);
+    expectedCrc.update(bodySlice.nioBuffer());
+    int expectedChecksum = (int) expectedCrc.getValue();
+
+    int idx = 0;
+    assertEquals("headerLength at offset 0", headerLength, buffer.getShort(idx));
+    idx += 2;
+    assertEquals("version at offset 2", expectedVersion, buffer.getShort(idx));
+    idx += 2;
+    assertEquals("extraHeaderContentLength at offset 4", expectedExtraHeaderLen, buffer.getShort(idx));
+    idx += 2;
+    idx += expectedExtraHeaderLen;
+
+    assertEquals("crc checksum", expectedChecksum, buffer.getInt(idx));
+    idx += 4;
+    assertEquals("compression id", compression.id, buffer.getByte(idx));
+    idx += 1;
+    assertEquals("message count", messageCount, buffer.getInt(idx));
+    idx += 4;
+    int expectedPayloadLength = buffer.readableBytes() - headerLength;
+    assertEquals("payload length", expectedPayloadLength, buffer.getInt(idx));
+    idx += 4;
+
+    assertEquals("final idx must equal headerLength", headerLength, idx);
+
+    buffer.release();
+  }
+
+  /**
+   * Write a header via TaskRequest, then read it back using the ByteBuf
+   * constructor and verify all parsed fields match.
+   */
+  @Test
+  public void testWriteHeaderRoundTripViaByteBuf() throws Exception {
+    int logMessageCount = 5;
+    Compression compression = Compression.NONE;
+    long epoch = 9999L;
+    long clientRequestId = 77L;
+
+    StubTaskRequest tr = new StubTaskRequest("roundtrip", clientRequestId, 20000);
+    tr.setEpochForTest(epoch);
+    tr.setCompressionForTest(compression);
+    for (int i = 0; i < logMessageCount; i++) {
+      tr.incrementLogMessageCountForTest();
+    }
+
+    byte[] payload = new byte[256];
+    for (int i = 0; i < payload.length; i++) {
+      payload[i] = (byte) (i & 0xFF);
+    }
+    short headerLength = MemqMessageHeader.getHeaderLength();
+    ByteBuf buffer = Unpooled.buffer(headerLength + payload.length);
+    buffer.writerIndex(headerLength);
+    buffer.writeBytes(payload);
+
+    new MemqMessageHeader(tr).writeHeader(buffer);
+
+    ByteBuf readBuf = buffer.duplicate();
+    readBuf.readerIndex(0);
+    MemqMessageHeader readHeader = new MemqMessageHeader(readBuf);
+
+    assertEquals("version", tr.getVersion(), readHeader.getVersion());
+    assertEquals("compression", compression.id, readHeader.getCompression());
+    assertEquals("logmessage count", logMessageCount, readHeader.getLogmessageCount());
+    assertEquals("message length (payload)", payload.length, readHeader.getMessageLength());
+    assertEquals("producer epoch", epoch, readHeader.getProducerEpoch());
+    assertEquals("producer request id", clientRequestId, readHeader.getProducerRequestId());
+    assertArrayEquals("producer address", MemqUtils.HOST_IPV4_ADDRESS, readHeader.getProducerAddress());
+
+    CRC32 expectedCrc = new CRC32();
+    expectedCrc.update(payload);
+    assertEquals("crc", (int) expectedCrc.getValue(), readHeader.getCrc());
+
+    buffer.release();
+  }
+
+  /**
+   * Write a header, then read it back using the ByteBuffer constructor
+   * and verify all parsed fields match.
+   */
+  @Test
+  public void testWriteHeaderRoundTripViaByteBuffer() throws Exception {
+    int logMessageCount = 10;
+    Compression compression = Compression.GZIP;
+    long epoch = 42L;
+    long clientRequestId = 101L;
+
+    StubTaskRequest tr = new StubTaskRequest("bytebuffer", clientRequestId, 20000);
+    tr.setEpochForTest(epoch);
+    tr.setCompressionForTest(compression);
+    for (int i = 0; i < logMessageCount; i++) {
+      tr.incrementLogMessageCountForTest();
+    }
+
+    byte[] payload = "round trip via ByteBuffer".getBytes();
+    short headerLength = MemqMessageHeader.getHeaderLength();
+    ByteBuf buffer = Unpooled.buffer(headerLength + payload.length);
+    buffer.writerIndex(headerLength);
+    buffer.writeBytes(payload);
+
+    new MemqMessageHeader(tr).writeHeader(buffer);
+
+    byte[] allBytes = new byte[buffer.readableBytes()];
+    buffer.getBytes(0, allBytes);
+    ByteBuffer bb = ByteBuffer.wrap(allBytes);
+
+    MemqMessageHeader readHeader = new MemqMessageHeader(bb);
+
+    assertEquals("version", tr.getVersion(), readHeader.getVersion());
+    assertEquals("compression", compression.id, readHeader.getCompression());
+    assertEquals("logmessage count", logMessageCount, readHeader.getLogmessageCount());
+    assertEquals("message length", payload.length, readHeader.getMessageLength());
+    assertEquals("producer epoch", epoch, readHeader.getProducerEpoch());
+    assertEquals("producer request id", clientRequestId, readHeader.getProducerRequestId());
+
+    buffer.release();
+  }
+
+  /**
+   * writeHeader on a PooledSlicedByteBuf — the scenario the absolute-index
+   * set methods were introduced to fix.
+   */
+  @Test
+  public void testWriteHeaderOnSlicedByteBuf() throws Exception {
+    int logMessageCount = 2;
+    Compression compression = Compression.NONE;
+
+    StubTaskRequest tr = new StubTaskRequest("slicetest", 55, 20000);
+    tr.setCompressionForTest(compression);
+    for (int i = 0; i < logMessageCount; i++) {
+      tr.incrementLogMessageCountForTest();
+    }
+
+    byte[] payload = "sliced payload data".getBytes();
+    short headerLength = MemqMessageHeader.getHeaderLength();
+
+    int prefixSize = 64;
+    ByteBuf parent = PooledByteBufAllocator.DEFAULT.buffer(prefixSize + headerLength + payload.length);
+    parent.writeBytes(new byte[prefixSize]);
+    parent.writeBytes(new byte[headerLength]);
+    parent.writeBytes(payload);
+
+    ByteBuf slice = parent.slice(prefixSize, headerLength + payload.length);
+
+    new MemqMessageHeader(tr).writeHeader(slice);
+
+    ByteBuf readBuf = slice.duplicate();
+    readBuf.readerIndex(0);
+    MemqMessageHeader readHeader = new MemqMessageHeader(readBuf);
+
+    assertEquals("version", tr.getVersion(), readHeader.getVersion());
+    assertEquals("compression", compression.id, readHeader.getCompression());
+    assertEquals("logmessage count", logMessageCount, readHeader.getLogmessageCount());
+    assertEquals("message length", payload.length, readHeader.getMessageLength());
+
+    CRC32 expectedCrc = new CRC32();
+    expectedCrc.update(payload);
+    assertEquals("crc", (int) expectedCrc.getValue(), readHeader.getCrc());
+
+    parent.release();
+  }
+
+  /**
+   * Simulate the real producer path: reserve headerLength zero bytes via
+   * OutputStream, write payload, then call writeHeader to fill in the
+   * reserved space.
+   */
+  @Test
+  public void testWriteHeaderWithOutputStreamReservedSpace() throws Exception {
+    int logMessageCount = 4;
+    Compression compression = Compression.NONE;
+
+    StubTaskRequest tr = new StubTaskRequest("realpath", 88, 20000);
+    tr.setCompressionForTest(compression);
+    for (int i = 0; i < logMessageCount; i++) {
+      tr.incrementLogMessageCountForTest();
+    }
+
+    short headerLength = MemqMessageHeader.getHeaderLength();
+    ByteBuf buffer = PooledByteBufAllocator.DEFAULT.buffer(1024);
+    ByteBufOutputStream os = new ByteBufOutputStream(buffer);
+    os.write(new byte[headerLength]);
+    byte[] payload = "output stream test payload".getBytes();
+    os.write(payload);
+    os.close();
+
+    new MemqMessageHeader(tr).writeHeader(buffer);
+
+    ByteBuf readBuf = buffer.duplicate();
+    readBuf.readerIndex(0);
+    MemqMessageHeader readHeader = new MemqMessageHeader(readBuf);
+
+    assertEquals("version", tr.getVersion(), readHeader.getVersion());
+    assertEquals("compression", compression.id, readHeader.getCompression());
+    assertEquals("logmessage count", logMessageCount, readHeader.getLogmessageCount());
+    assertEquals("message length", payload.length, readHeader.getMessageLength());
+
+    CRC32 expectedCrc = new CRC32();
+    expectedCrc.update(payload);
+    assertEquals("crc", (int) expectedCrc.getValue(), readHeader.getCrc());
+
+    buffer.release();
+  }
+
+  private static class StubTaskRequest extends TaskRequest {
+    private long epoch = 0;
+
+    public StubTaskRequest(String topicName, long currentRequestId,
+                           int maxPayLoadBytes) throws IOException {
+      super(topicName, currentRequestId, Compression.NONE, null, false, maxPayLoadBytes, 10000,
+          null, 10000);
+    }
+
+    @Override
+    protected MemqWriteResult runRequest() throws Exception {
+      return null;
+    }
+
+    @Override
+    public long getEpoch() {
+      return epoch;
+    }
+
+    public void setEpochForTest(long epoch) {
+      this.epoch = epoch;
+    }
+
+    public void setCompressionForTest(Compression c) {
+      this.compression = c;
+    }
+
+    public void incrementLogMessageCountForTest() {
+      incrementLogMessageCount();
+    }
+  }
+}

--- a/memq-client/src/test/java/com/pinterest/memq/client/commons2/TestMemqCommonClient.java
+++ b/memq-client/src/test/java/com/pinterest/memq/client/commons2/TestMemqCommonClient.java
@@ -533,4 +533,44 @@ public class TestMemqCommonClient {
     client.close();
     server.stop();
   }
+
+  @Test
+  public void testGetTopics() throws Exception {
+    Map<RequestType, BiConsumer<ChannelHandlerContext, RequestPacket>> map = new HashMap<>();
+
+    map.put(RequestType.TOPIC_METADATA, (ctx, req) -> {
+      TopicMetadataRequestPacket mdPkt = (TopicMetadataRequestPacket) req.getPayload();
+      if (mdPkt.getTopics().isEmpty()) {
+        List<TopicMetadata> allMetadata = Arrays.asList(
+            new TopicMetadata("topicA", "handler", new Properties()),
+            new TopicMetadata("topicB", "handler", new Properties()),
+            new TopicMetadata("topicC", "handler", new Properties()));
+        ctx.writeAndFlush(new ResponsePacket(req.getProtocolVersion(), req.getClientRequestId(),
+            req.getRequestType(), ResponseCodes.OK, new TopicMetadataResponsePacket(allMetadata)));
+      } else {
+        TopicMetadata md = new TopicMetadata(mdPkt.getTopic(), "handler", new Properties());
+        ctx.writeAndFlush(new ResponsePacket(req.getProtocolVersion(), req.getClientRequestId(),
+            req.getRequestType(), ResponseCodes.OK, new TopicMetadataResponsePacket(md)));
+      }
+    });
+
+    MockMemqServer mockServer = new MockMemqServer(port, map);
+    mockServer.start();
+
+    MemqCommonClient client = new MemqCommonClient("", null, new Properties());
+    client.initialize(Collections.singletonList(commonEndpoint));
+
+    java.util.Collection<TopicMetadata> topics = client.getTopics();
+    assertEquals(3, topics.size());
+    Set<String> topicNames = new HashSet<>();
+    for (TopicMetadata md : topics) {
+      topicNames.add(md.getTopicName());
+    }
+    assertTrue(topicNames.contains("topicA"));
+    assertTrue(topicNames.contains("topicB"));
+    assertTrue(topicNames.contains("topicC"));
+
+    client.close();
+    mockServer.stop();
+  }
 }

--- a/memq-client/src/test/java/com/pinterest/memq/client/consumer/TestMemqConsumer.java
+++ b/memq-client/src/test/java/com/pinterest/memq/client/consumer/TestMemqConsumer.java
@@ -20,6 +20,7 @@ import static com.pinterest.memq.client.commons.ConsumerConfigs.KEY_DESERIALIZER
 import static com.pinterest.memq.client.commons.ConsumerConfigs.VALUE_DESERIALIZER_CLASS_KEY;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -488,6 +489,158 @@ public class TestMemqConsumer {
     } finally {
       mc.close();
     }
+  }
+
+  @Test
+  public void testBytesConsumedTotalTracksBytes() throws Exception {
+    byte[] batchData = new byte[]{1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+    Properties mcProps = new Properties();
+    mcProps.put(KEY_DESERIALIZER_CLASS_KEY, ByteArrayDeserializer.class.getName());
+    mcProps.put(VALUE_DESERIALIZER_CLASS_KEY, ByteArrayDeserializer.class.getName());
+    mcProps.put(DRY_RUN_KEY, "true");
+    MemqInput input = new MemqInput() {
+      @Override
+      public InputStream fetchBatchStreamForNotification(JsonObject nextNotificationToProcess) {
+        return new ByteArrayInputStream(batchData);
+      }
+
+      @Override
+      public DataInputStream fetchMessageAtIndex(JsonObject objectNotification,
+                                                 IndexEntry index) throws IOException {
+        return null;
+      }
+
+      @Override
+      public BatchHeader fetchHeaderForBatch(JsonObject nextNotificationToProcess) throws IOException {
+        return null;
+      }
+
+      @Override
+      public void initReader(Properties properties, MetricRegistry registry) throws Exception {
+      }
+    };
+    MemqConsumer<byte[], byte[]> mc = new MemqConsumer<>(mcProps, input);
+
+    assertEquals(0, mc.getBytesConsumedTotal());
+
+    JsonObject notification = new JsonObject();
+    notification.addProperty("objectSize", batchData.length);
+
+    mc.fetchObjectToInputStream(notification);
+    assertEquals(batchData.length, mc.getBytesConsumedTotal());
+
+    mc.fetchObjectToInputStream(notification);
+    assertEquals(batchData.length * 2, mc.getBytesConsumedTotal());
+
+    mc.close();
+  }
+
+  @Test
+  public void testBytesConsumedTotalNotIncrementedOnError() throws Exception {
+    Properties mcProps = new Properties();
+    mcProps.put(KEY_DESERIALIZER_CLASS_KEY, ByteArrayDeserializer.class.getName());
+    mcProps.put(VALUE_DESERIALIZER_CLASS_KEY, ByteArrayDeserializer.class.getName());
+    mcProps.put(DRY_RUN_KEY, "true");
+    MemqInput input = new MemqInput() {
+      @Override
+      public InputStream fetchBatchStreamForNotification(JsonObject nextNotificationToProcess)
+          throws IOException {
+        throw new IOException("simulated S3 failure");
+      }
+
+      @Override
+      public DataInputStream fetchMessageAtIndex(JsonObject objectNotification,
+                                                 IndexEntry index) throws IOException {
+        return null;
+      }
+
+      @Override
+      public BatchHeader fetchHeaderForBatch(JsonObject nextNotificationToProcess) throws IOException {
+        return null;
+      }
+
+      @Override
+      public void initReader(Properties properties, MetricRegistry registry) throws Exception {
+      }
+    };
+    MemqConsumer<byte[], byte[]> mc = new MemqConsumer<>(mcProps, input);
+
+    assertEquals(0, mc.getBytesConsumedTotal());
+
+    JsonObject notification = new JsonObject();
+    notification.addProperty("objectSize", 100);
+
+    try {
+      mc.fetchObjectToInputStream(notification);
+      fail("Expected IOException");
+    } catch (IOException expected) {
+    }
+
+    assertEquals(0, mc.getBytesConsumedTotal());
+    mc.close();
+  }
+
+  @Test
+  public void testGetNotificationConsumerMetricsWithoutNotificationSource() throws Exception {
+    Properties mcProps = new Properties();
+    mcProps.put(DRY_RUN_KEY, "true");
+    mcProps.put(KEY_DESERIALIZER_CLASS_KEY, ByteArrayDeserializer.class.getName());
+    mcProps.put(VALUE_DESERIALIZER_CLASS_KEY, ByteArrayDeserializer.class.getName());
+    MemqConsumer<byte[], byte[]> mc = new MemqConsumer<>(mcProps);
+
+    Map<org.apache.kafka.common.MetricName, ? extends org.apache.kafka.common.Metric> metrics =
+        mc.getNotificationConsumerMetrics();
+    assertNotNull(metrics);
+    assertTrue(metrics.isEmpty());
+
+    mc.close();
+  }
+
+  @Test
+  public void testGetNotificationConsumerMetricsWithMockConsumer() throws Exception {
+    Properties mcProps = new Properties();
+    mcProps.put(DRY_RUN_KEY, "true");
+    mcProps.put(KEY_DESERIALIZER_CLASS_KEY, ByteArrayDeserializer.class.getName());
+    mcProps.put(VALUE_DESERIALIZER_CLASS_KEY, ByteArrayDeserializer.class.getName());
+    MemqInput input = new MemqInput() {
+      @Override
+      public InputStream fetchBatchStreamForNotification(JsonObject nextNotificationToProcess) {
+        return new ByteArrayInputStream(new byte[0]);
+      }
+
+      @Override
+      public DataInputStream fetchMessageAtIndex(JsonObject objectNotification,
+                                                 IndexEntry index) throws IOException {
+        return null;
+      }
+
+      @Override
+      public BatchHeader fetchHeaderForBatch(JsonObject nextNotificationToProcess) throws IOException {
+        return null;
+      }
+
+      @Override
+      public void initReader(Properties properties, MetricRegistry registry) throws Exception {
+      }
+    };
+    MemqConsumer<byte[], byte[]> mc = new MemqConsumer<>(mcProps, input);
+
+    // before setting notification source, metrics should be empty
+    assertTrue(mc.getNotificationConsumerMetrics().isEmpty());
+
+    MockConsumer<String, String> mockKafkaConsumer = new MockConsumer<>(OffsetResetStrategy.EARLIEST);
+    KafkaNotificationSource notificationSource = new KafkaNotificationSource(mockKafkaConsumer);
+    notificationSource.setParentConsumer(mc);
+    mc.setNotificationSource(notificationSource);
+
+    // after setting notification source, should delegate to the underlying Kafka consumer
+    Map<org.apache.kafka.common.MetricName, ? extends org.apache.kafka.common.Metric> metrics =
+        mc.getNotificationConsumerMetrics();
+    assertNotNull(metrics);
+    // metrics map is the same instance as what the underlying consumer returns
+    assertEquals(mockKafkaConsumer.metrics(), metrics);
+
+    mc.close();
   }
 
   public abstract class MemqInput implements StorageHandler {

--- a/memq-client/src/test/java/com/pinterest/memq/client/consumer/TestMemqConsumer.java
+++ b/memq-client/src/test/java/com/pinterest/memq/client/consumer/TestMemqConsumer.java
@@ -476,6 +476,20 @@ public class TestMemqConsumer {
     assertEquals("Skip to last MUST yield only 1 message", 1, i);
   }
 
+  @Test(expected = IllegalStateException.class)
+  public void testGetTopicsThrowsForDirectConsumer() throws Exception {
+    Properties mcProps = new Properties();
+    mcProps.put(DRY_RUN_KEY, "true");
+    mcProps.put(KEY_DESERIALIZER_CLASS_KEY, ByteArrayDeserializer.class.getName());
+    mcProps.put(VALUE_DESERIALIZER_CLASS_KEY, ByteArrayDeserializer.class.getName());
+    MemqConsumer<byte[], byte[]> mc = new MemqConsumer<>(mcProps);
+    try {
+      mc.getTopics();
+    } finally {
+      mc.close();
+    }
+  }
+
   public abstract class MemqInput implements StorageHandler {
 
     @Override

--- a/memq-client/src/test/java/com/pinterest/memq/client/consumer/TestMemqConsumer.java
+++ b/memq-client/src/test/java/com/pinterest/memq/client/consumer/TestMemqConsumer.java
@@ -20,7 +20,6 @@ import static com.pinterest.memq.client.commons.ConsumerConfigs.KEY_DESERIALIZER
 import static com.pinterest.memq.client.commons.ConsumerConfigs.VALUE_DESERIALIZER_CLASS_KEY;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -53,6 +52,7 @@ import org.apache.kafka.common.record.TimestampType;
 import org.apache.kafka.common.utils.ByteBufferOutputStream;
 import org.junit.Test;
 
+import com.codahale.metrics.Gauge;
 import com.codahale.metrics.MetricRegistry;
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
@@ -521,16 +521,18 @@ public class TestMemqConsumer {
     };
     MemqConsumer<byte[], byte[]> mc = new MemqConsumer<>(mcProps, input);
 
-    assertEquals(0, mc.getBytesConsumedTotal());
+    com.codahale.metrics.Counter bytesCounter =
+        mc.getMetricRegistry().counter(MemqConsumer.BYTES_CONSUMED_TOTAL_METRIC);
+    assertEquals(0, bytesCounter.getCount());
 
     JsonObject notification = new JsonObject();
     notification.addProperty("objectSize", batchData.length);
 
     mc.fetchObjectToInputStream(notification);
-    assertEquals(batchData.length, mc.getBytesConsumedTotal());
+    assertEquals(batchData.length, bytesCounter.getCount());
 
     mc.fetchObjectToInputStream(notification);
-    assertEquals(batchData.length * 2, mc.getBytesConsumedTotal());
+    assertEquals(batchData.length * 2, bytesCounter.getCount());
 
     mc.close();
   }
@@ -565,7 +567,9 @@ public class TestMemqConsumer {
     };
     MemqConsumer<byte[], byte[]> mc = new MemqConsumer<>(mcProps, input);
 
-    assertEquals(0, mc.getBytesConsumedTotal());
+    com.codahale.metrics.Counter bytesCounter =
+        mc.getMetricRegistry().counter(MemqConsumer.BYTES_CONSUMED_TOTAL_METRIC);
+    assertEquals(0, bytesCounter.getCount());
 
     JsonObject notification = new JsonObject();
     notification.addProperty("objectSize", 100);
@@ -576,28 +580,28 @@ public class TestMemqConsumer {
     } catch (IOException expected) {
     }
 
-    assertEquals(0, mc.getBytesConsumedTotal());
+    assertEquals(0, bytesCounter.getCount());
     mc.close();
   }
 
   @Test
-  public void testGetNotificationConsumerMetricsWithoutNotificationSource() throws Exception {
+  public void testNotificationRecordsLagGaugeWithoutNotificationSource() throws Exception {
     Properties mcProps = new Properties();
     mcProps.put(DRY_RUN_KEY, "true");
     mcProps.put(KEY_DESERIALIZER_CLASS_KEY, ByteArrayDeserializer.class.getName());
     mcProps.put(VALUE_DESERIALIZER_CLASS_KEY, ByteArrayDeserializer.class.getName());
     MemqConsumer<byte[], byte[]> mc = new MemqConsumer<>(mcProps);
 
-    Map<org.apache.kafka.common.MetricName, ? extends org.apache.kafka.common.Metric> metrics =
-        mc.getNotificationConsumerMetrics();
-    assertNotNull(metrics);
-    assertTrue(metrics.isEmpty());
+    // without notification source, no lag gauge should be registered
+    assertFalse(mc.getMetricRegistry().getGauges()
+        .containsKey(MemqConsumer.NOTIFICATION_RECORDS_LAG_MAX_METRIC));
 
     mc.close();
   }
 
+  @SuppressWarnings("unchecked")
   @Test
-  public void testGetNotificationConsumerMetricsWithMockConsumer() throws Exception {
+  public void testNotificationRecordsLagGaugeWithMockConsumer() throws Exception {
     Properties mcProps = new Properties();
     mcProps.put(DRY_RUN_KEY, "true");
     mcProps.put(KEY_DESERIALIZER_CLASS_KEY, ByteArrayDeserializer.class.getName());
@@ -625,20 +629,24 @@ public class TestMemqConsumer {
     };
     MemqConsumer<byte[], byte[]> mc = new MemqConsumer<>(mcProps, input);
 
-    // before setting notification source, metrics should be empty
-    assertTrue(mc.getNotificationConsumerMetrics().isEmpty());
+    // before setting notification source, gauge should not be registered
+    assertFalse(mc.getMetricRegistry().getGauges()
+        .containsKey(MemqConsumer.NOTIFICATION_RECORDS_LAG_MAX_METRIC));
 
     MockConsumer<String, String> mockKafkaConsumer = new MockConsumer<>(OffsetResetStrategy.EARLIEST);
     KafkaNotificationSource notificationSource = new KafkaNotificationSource(mockKafkaConsumer);
     notificationSource.setParentConsumer(mc);
     mc.setNotificationSource(notificationSource);
 
-    // after setting notification source, should delegate to the underlying Kafka consumer
-    Map<org.apache.kafka.common.MetricName, ? extends org.apache.kafka.common.Metric> metrics =
-        mc.getNotificationConsumerMetrics();
-    assertNotNull(metrics);
-    // metrics map is the same instance as what the underlying consumer returns
-    assertEquals(mockKafkaConsumer.metrics(), metrics);
+    // after setting notification source, gauge should be registered
+    assertTrue(mc.getMetricRegistry().getGauges()
+        .containsKey(MemqConsumer.NOTIFICATION_RECORDS_LAG_MAX_METRIC));
+
+    // MockConsumer has no records-lag-max metric, so gauge should return NaN
+    Gauge<Double> lagGauge =
+        (Gauge<Double>) mc.getMetricRegistry().getGauges()
+            .get(MemqConsumer.NOTIFICATION_RECORDS_LAG_MAX_METRIC);
+    assertTrue(Double.isNaN(lagGauge.getValue()));
 
     mc.close();
   }

--- a/memq-commons/pom.xml
+++ b/memq-commons/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>com.pinterest.memq</groupId>
 		<artifactId>memq-parent</artifactId>
-		<version>1.0.1</version>
+		<version>1.0.2-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<artifactId>memq-commons</artifactId>

--- a/memq-commons/src/main/java/com/pinterest/memq/commons/protocol/TopicMetadataRequestPacket.java
+++ b/memq-commons/src/main/java/com/pinterest/memq/commons/protocol/TopicMetadataRequestPacket.java
@@ -16,37 +16,65 @@
 package com.pinterest.memq.commons.protocol;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
 
 import io.netty.buffer.ByteBuf;
 
+/**
+ * Wire format: topic strings written consecutively with 2-byte length encoding.
+ * An empty list signals "list all topics".
+ * <p>
+ * Backward compatible: old clients write 1 string, new brokers read all
+ * available; new clients writing N strings to old brokers is safe because
+ * old brokers read only the first string.
+ */
 public class TopicMetadataRequestPacket implements Packet {
 
-  private String topic;
+  private List<String> topics = Collections.emptyList();
 
   public TopicMetadataRequestPacket() {
   }
 
   public TopicMetadataRequestPacket(String topic) {
-    this.topic = topic;
+    this.topics = Collections.singletonList(topic);
+  }
+
+  public TopicMetadataRequestPacket(Collection<String> topics) {
+    this.topics = new ArrayList<>(topics);
   }
 
   @Override
   public void readFields(ByteBuf buf, short protocolVersion) throws IOException {
-    topic = ProtocolUtils.readStringWithTwoByteEncoding(buf);
+    topics = new ArrayList<>();
+    while (buf.isReadable()) {
+      topics.add(ProtocolUtils.readStringWithTwoByteEncoding(buf));
+    }
   }
 
   @Override
   public void write(ByteBuf buf, short protocolVersion) {
-    ProtocolUtils.writeStringWithTwoByteEncoding(buf, topic);
+    for (String topic : topics) {
+      ProtocolUtils.writeStringWithTwoByteEncoding(buf, topic);
+    }
   }
 
   @Override
   public int getSize(short protocolVersion) {
-    return ProtocolUtils.getStringSerializedSizeWithTwoByteEncoding(topic);
-  }
-  
-  public String getTopic() {
-    return topic;
+    int size = 0;
+    for (String topic : topics) {
+      size += ProtocolUtils.getStringSerializedSizeWithTwoByteEncoding(topic);
+    }
+    return size;
   }
 
+  public String getTopic() {
+    return topics.isEmpty() ? null : topics.get(0);
+  }
+
+  public List<String> getTopics() {
+    return topics;
+  }
 }

--- a/memq-commons/src/main/java/com/pinterest/memq/commons/protocol/TopicMetadataResponsePacket.java
+++ b/memq-commons/src/main/java/com/pinterest/memq/commons/protocol/TopicMetadataResponsePacket.java
@@ -16,43 +16,71 @@
 package com.pinterest.memq.commons.protocol;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
 
 import io.netty.buffer.ByteBuf;
 
+/**
+ * Wire format: TopicMetadata objects written consecutively.
+ * <p>
+ * Backward compatible: old brokers write 1 metadata, new clients read all
+ * available (get 1). New brokers writing N metadata to old clients is safe
+ * because old clients read only the first.
+ */
 public class TopicMetadataResponsePacket implements Packet {
 
-  private TopicMetadata metadata;
+  private List<TopicMetadata> metadataList = new ArrayList<>();
 
   public TopicMetadataResponsePacket() {
   }
 
   public TopicMetadataResponsePacket(TopicMetadata metadata) {
-    this.metadata = metadata;
+    this.metadataList = Collections.singletonList(metadata);
+  }
+
+  public TopicMetadataResponsePacket(Collection<TopicMetadata> metadataList) {
+    this.metadataList = new ArrayList<>(metadataList);
   }
 
   @Override
   public void readFields(ByteBuf buf, short protocolVersion) throws IOException {
-    metadata = new TopicMetadata();
-    metadata.readFields(buf, protocolVersion);
+    metadataList = new ArrayList<>();
+    while (buf.isReadable()) {
+      TopicMetadata md = new TopicMetadata();
+      md.readFields(buf, protocolVersion);
+      metadataList.add(md);
+    }
   }
 
   @Override
   public void write(ByteBuf buf, short protocolVersion) {
-    metadata.write(buf, protocolVersion);
+    for (TopicMetadata md : metadataList) {
+      md.write(buf, protocolVersion);
+    }
   }
 
   @Override
   public int getSize(short protocolVersion) {
-    return metadata.getSize(protocolVersion);
+    int size = 0;
+    for (TopicMetadata md : metadataList) {
+      size += md.getSize(protocolVersion);
+    }
+    return size;
   }
 
   public TopicMetadata getMetadata() {
-    return metadata;
+    return metadataList.isEmpty() ? null : metadataList.get(0);
+  }
+
+  public List<TopicMetadata> getMetadataList() {
+    return metadataList;
   }
 
   @Override
   public String toString() {
-    return "TopicMetadataResponsePacket [metadata=" + metadata + "]";
+    return "TopicMetadataResponsePacket [metadataList=" + metadataList + "]";
   }
-
 }

--- a/memq-commons/src/test/java/com/pinterest/memq/commons/protocol/TestTopicMetadataPacket.java
+++ b/memq-commons/src/test/java/com/pinterest/memq/commons/protocol/TestTopicMetadataPacket.java
@@ -16,9 +16,13 @@
 package com.pinterest.memq.commons.protocol;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Properties;
 
 import org.junit.Test;
@@ -71,6 +75,70 @@ public class TestTopicMetadataPacket {
     metadata = response.getMetadata();
     assertEquals("test23", metadata.getTopicName());
     assertEquals("delayeddevnull", metadata.getStorageHandlerName());
+  }
+
+  @Test
+  public void testListTopicsRoundTrip() throws IOException {
+    // empty request = list all topics
+    TopicMetadataRequestPacket request = new TopicMetadataRequestPacket(Collections.emptyList());
+    ByteBuf reqBuf = PooledByteBufAllocator.DEFAULT.buffer();
+    request.write(reqBuf, RequestType.PROTOCOL_VERSION);
+
+    request = new TopicMetadataRequestPacket();
+    request.readFields(reqBuf, RequestType.PROTOCOL_VERSION);
+    assertTrue(request.getTopics().isEmpty());
+    reqBuf.release();
+
+    // response with multiple TopicMetadata objects
+    TopicMetadata mdA = new TopicMetadata("topicA", "handlerA", new Properties());
+    TopicMetadata mdB = new TopicMetadata("topicB", "handlerB", new Properties());
+    TopicMetadata mdC = new TopicMetadata("topicC", "handlerC", new Properties());
+    List<TopicMetadata> allMetadata = Arrays.asList(mdA, mdB, mdC);
+
+    TopicMetadataResponsePacket response = new TopicMetadataResponsePacket(allMetadata);
+    ByteBuf respBuf = PooledByteBufAllocator.DEFAULT.buffer();
+    response.write(respBuf, RequestType.PROTOCOL_VERSION);
+
+    response = new TopicMetadataResponsePacket();
+    response.readFields(respBuf, RequestType.PROTOCOL_VERSION);
+
+    List<TopicMetadata> metadataList = response.getMetadataList();
+    assertEquals(3, metadataList.size());
+    assertEquals("topicA", metadataList.get(0).getTopicName());
+    assertEquals("topicB", metadataList.get(1).getTopicName());
+    assertEquals("topicC", metadataList.get(2).getTopicName());
+    respBuf.release();
+  }
+
+  @Test
+  public void testBackwardCompatSingleTopicRequestReadByNewBroker() throws IOException {
+    // old client writes a single topic string
+    TopicMetadataRequestPacket oldRequest = new TopicMetadataRequestPacket("myTopic");
+    ByteBuf buf = PooledByteBufAllocator.DEFAULT.buffer();
+    oldRequest.write(buf, RequestType.PROTOCOL_VERSION);
+
+    // new broker reads it — should see exactly 1 topic
+    TopicMetadataRequestPacket newBrokerRead = new TopicMetadataRequestPacket();
+    newBrokerRead.readFields(buf, RequestType.PROTOCOL_VERSION);
+    assertEquals(1, newBrokerRead.getTopics().size());
+    assertEquals("myTopic", newBrokerRead.getTopic());
+    buf.release();
+  }
+
+  @Test
+  public void testBackwardCompatSingleResponseReadByNewClient() throws IOException {
+    // old broker writes a single TopicMetadata
+    TopicMetadata md = new TopicMetadata("test", "handler", new Properties());
+    TopicMetadataResponsePacket oldResponse = new TopicMetadataResponsePacket(md);
+    ByteBuf buf = PooledByteBufAllocator.DEFAULT.buffer();
+    oldResponse.write(buf, RequestType.PROTOCOL_VERSION);
+
+    // new client reads it — should see exactly 1 metadata via getMetadataList()
+    TopicMetadataResponsePacket newClientRead = new TopicMetadataResponsePacket();
+    newClientRead.readFields(buf, RequestType.PROTOCOL_VERSION);
+    assertEquals(1, newClientRead.getMetadataList().size());
+    assertEquals("test", newClientRead.getMetadata().getTopicName());
+    buf.release();
   }
 
 }

--- a/memq-examples/pom.xml
+++ b/memq-examples/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>com.pinterest.memq</groupId>
 		<artifactId>memq-parent</artifactId>
-		<version>1.0.1</version>
+		<version>1.0.2-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<artifactId>memq-examples</artifactId>

--- a/memq/pom.xml
+++ b/memq/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>com.pinterest.memq</groupId>
 		<artifactId>memq-parent</artifactId>
-		<version>1.0.1</version>
+		<version>1.0.2-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<artifactId>memq</artifactId>

--- a/memq/src/main/java/com/pinterest/memq/core/rpc/PacketSwitchingHandler.java
+++ b/memq/src/main/java/com/pinterest/memq/core/rpc/PacketSwitchingHandler.java
@@ -16,6 +16,8 @@
 package com.pinterest.memq.core.rpc;
 
 import java.security.Principal;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.logging.Logger;
 
 import javax.ws.rs.InternalServerErrorException;
@@ -88,15 +90,23 @@ public class PacketSwitchingHandler {
     case TOPIC_METADATA:
       TopicMetadataRequestPacket mdRequest = (TopicMetadataRequestPacket) requestPacket
           .getPayload();
-      TopicMetadata md = governor.getTopicMetadataMap().get(mdRequest.getTopic());
-      if (md == null) {
-        throw TOPIC_NOT_FOUND;
+      List<String> requestedTopics = mdRequest.getTopics();
+      List<TopicMetadata> results;
+      if (requestedTopics.isEmpty()) {
+        results = new ArrayList<>(governor.getTopicMetadataMap().values());
       } else {
-        ResponsePacket msg = new ResponsePacket(requestPacket.getProtocolVersion(),
-            requestPacket.getClientRequestId(), requestPacket.getRequestType(), ResponseCodes.OK,
-            new TopicMetadataResponsePacket(md));
-        ctx.writeAndFlush(msg);
+        results = new ArrayList<>(requestedTopics.size());
+        for (String t : requestedTopics) {
+          TopicMetadata md = governor.getTopicMetadataMap().get(t);
+          if (md == null) {
+            throw new NotFoundException("Topic not found:" + t);
+          }
+          results.add(md);
+        }
       }
+      ctx.writeAndFlush(new ResponsePacket(requestPacket.getProtocolVersion(),
+          requestPacket.getClientRequestId(), requestPacket.getRequestType(), ResponseCodes.OK,
+          new TopicMetadataResponsePacket(results)));
       break;
     case READ:
       ReadRequestPacket readPacket = (ReadRequestPacket) requestPacket.getPayload();

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.pinterest.memq</groupId>
 	<artifactId>memq-parent</artifactId>
-	<version>1.0.1</version>
+	<version>1.0.2-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	<name>memq-parent</name>
 	<description>Hyperscale PubSub System</description>


### PR DESCRIPTION
## Summary
Three major improvements to MemqConsumer to support FlinkSQL integration:

### 1. listTopics support via protocol change
Extended `TopicMetadataRequestPacket` and `TopicMetadataResponsePacket` to support multi-topic requests and responses. An empty topic list signals "list all topics", enabling a new `MemqConsumer.getTopics()` API. The wire format change is backward compatible — old clients write 1 topic string, new brokers read all available; new clients sending N strings to old brokers is safe because old brokers read only the first.
Also fixed `MemqMessageHeader.writeHeader()` to use absolute-index `set*` methods instead of `duplicate()` + relative writes, because `PooledSlicedByteBuf.duplicate()` translates indices to the parent buffer's coordinate space, breaking `writerIndex(0)`.

### 2. Direct memory leak resolution in ReactorNettyRequestClient
`HttpClient.create()` was using Reactor Netty's global shared resources, creating unbounded event loop threads and connection pools that were never disposed. This caused `OutOfDirectMemoryError` in long-running Flink consumers. Fixed by:
- Creating bounded `LoopResources` (default 2 threads) and `ConnectionProvider` (default 64 max connections) per client instance
- Passing them to `HttpClient.create(connectionProvider).runOn(loopResources)`
- Properly disposing both in `close()` with timeout
- Adding a try-catch around direct buffer `IOUtils.copy` to ensure `byteBuf.release()` on failure
- Emitting Netty `PooledByteBufAllocator` memory gauges unconditionally (not only when `directBuffer=true`)

### 3. Consumer metrics exposure via Dropwizard MetricRegistry
Registered two new metrics in `MemqConsumer`'s existing Dropwizard `MetricRegistry` to support Flink source metrics (`numBytesIn` and `pendingRecords`) without introducing new public API methods:
- **`bytes.consumed.total`** — a Dropwizard `Counter` incremented in `fetchObjectToInputStream()` with the actual bytes fetched from S3. Exposed as `MemqConsumer.BYTES_CONSUMED_TOTAL_METRIC`.
- **`notification.records.lag.max`** — a Dropwizard `Gauge<Double>` registered after notification source initialization that lazily reads `records-lag-max` from the underlying Kafka notification consumer. Exposed as `MemqConsumer.NOTIFICATION_RECORDS_LAG_MAX_METRIC`. Returns `Double.NaN` when the metric is unavailable.

## Test plan
- [x] Unit tests for `bytes.consumed.total` counter: verifies counter starts at 0, accumulates across fetches, and is not incremented on fetch failure
- [x] Unit tests for `notification.records.lag.max` gauge: verifies gauge is not registered when no notification source is set, is registered after `setNotificationSource()`, and returns `NaN` when the underlying Kafka consumer has no `records-lag-max` metric
- [x] Unit tests for `TopicMetadataRequestPacket` / `TopicMetadataResponsePacket` serialization round-trip
- [x] Unit tests for `MemqCommonClient.getTopics()`
- [x] All existing `TestMemqConsumer` tests pass (15/15)