### PR TITLE
Bump version to 1.0.2

### DIFF
--- a/deploy/pom.xml
+++ b/deploy/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>com.pinterest.memq</groupId>
 		<artifactId>memq-parent</artifactId>
-		<version>1.0.2-SNAPSHOT</version>
+		<version>1.0.2</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<artifactId>memq-deploy</artifactId>

--- a/memq-client-all/pom.xml
+++ b/memq-client-all/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>com.pinterest.memq</groupId>
 		<artifactId>memq-parent</artifactId>
-		<version>1.0.2-SNAPSHOT</version>
+		<version>1.0.2</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<artifactId>memq-client-all</artifactId>
@@ -48,7 +48,7 @@
 		<dependency>
 			<groupId>com.pinterest.memq</groupId>
 			<artifactId>memq-client</artifactId>
-			<version>1.0.2-SNAPSHOT</version>
+			<version>1.0.2</version>
 		</dependency>
 	</dependencies>
 	<build>

--- a/memq-client/pom.xml
+++ b/memq-client/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>com.pinterest.memq</groupId>
 		<artifactId>memq-parent</artifactId>
-		<version>1.0.2-SNAPSHOT</version>
+		<version>1.0.2</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<artifactId>memq-client</artifactId>

--- a/memq-commons/pom.xml
+++ b/memq-commons/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>com.pinterest.memq</groupId>
 		<artifactId>memq-parent</artifactId>
-		<version>1.0.2-SNAPSHOT</version>
+		<version>1.0.2</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<artifactId>memq-commons</artifactId>

--- a/memq-examples/pom.xml
+++ b/memq-examples/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>com.pinterest.memq</groupId>
 		<artifactId>memq-parent</artifactId>
-		<version>1.0.2-SNAPSHOT</version>
+		<version>1.0.2</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<artifactId>memq-examples</artifactId>

--- a/memq/pom.xml
+++ b/memq/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>com.pinterest.memq</groupId>
 		<artifactId>memq-parent</artifactId>
-		<version>1.0.2-SNAPSHOT</version>
+		<version>1.0.2</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<artifactId>memq</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.pinterest.memq</groupId>
 	<artifactId>memq-parent</artifactId>
-	<version>1.0.2-SNAPSHOT</version>
+	<version>1.0.2</version>
 	<packaging>pom</packaging>
 	<name>memq-parent</name>
 	<description>Hyperscale PubSub System</description>


### PR DESCRIPTION
This release allows MemQ consumer to be compatible with FlinkSQL 1.18 API's. Changes in https://github.com/pinterest/memq/pull/51