### PR TITLE
Add MemQ Rust client library and E2E test suite

### DIFF
--- a/memq-rust-client/.gitignore
+++ b/memq-rust-client/.gitignore
@@ -1,0 +1,4 @@
+/target/
+*.pyc
+__pycache__/
+.DS_Store

--- a/memq-rust-client/Cargo.toml
+++ b/memq-rust-client/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "memq-rust-client"
+version = "0.1.0"
+edition = "2021"
+description = "MemQ client library: protocol parsing and storage format handling"
+
+[dependencies]
+crc32fast = "1"
+flate2 = "1"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+thiserror = "2"
+zstd = "0.13"
+
+# S3 presigned URL generation and fetch (rustls for TLS)
+aws-config = { version = "1", features = ["rustls"] }
+aws-sdk-s3 = { version = "1", features = ["rustls"] }
+aws-smithy-http = "0"
+
+# Kafka consumer for notification topic (pure Rust, vendored)
+kafka = { path = "../target/kafka-rust" }
+
+# HTTP client for presigned URL GET requests
+reqwest = { version = "0.12", features = ["blocking"] }
+
+# Tokio for AWS SDK async runtime
+tokio = { version = "1", features = ["rt-multi-thread", "net", "time"] }
+
+[dev-dependencies]
+base64 = "0.22"

--- a/memq-rust-client/examples/e2e_broker.rs
+++ b/memq-rust-client/examples/e2e_broker.rs
@@ -1,0 +1,88 @@
+/// End-to-end test: real MemQ broker + Kafka + Rust consumer.
+///
+/// 1. Java MemQ producer wrote messages to a topic
+/// 2. Broker stored them in /tmp/memq-storage
+/// 3. Broker pushed notification to Kafka
+/// 4. Rust consumer reads the batch from filesystem and verifies all messages
+
+use memq_rust_client::kafka::{AutoOffsetReset, KafkaNotificationConfig, KafkaNotificationSource};
+use memq_rust_client::storage::{FsStorageConfig, FsStorageHandler, StorageHandler};
+use memq_rust_client::Message;
+use std::path::PathBuf;
+use std::time::Duration;
+
+fn main() {
+    println!("=== MemQ Rust Consumer — End-to-End Test ===\n");
+
+    // --- Step 1: Read notification from Kafka ---
+    println!("Step 1: Read notification from Kafka...");
+
+    let config = KafkaNotificationConfig {
+        bootstrap_servers: vec!["localhost:9092".to_string()],
+        group_id: "rust-e2e-test-group".to_string(),
+        notification_topic: "TestTopicNotifications".to_string(),
+        auto_offset_reset: AutoOffsetReset::Earliest,
+        max_poll_records: 100,
+    };
+
+    let kafka_source = KafkaNotificationSource::new(config).expect("Failed to create KafkaNotificationSource");
+
+    // Poll for notifications (with a timeout)
+    let notifications = kafka_source.poll(Duration::from_secs(3)).expect("Kafka poll failed");
+    println!("  Notifications received: {}", notifications.len());
+
+    if notifications.is_empty() {
+        eprintln!("ERROR: No notifications received from Kafka!");
+        std::process::exit(1);
+    }
+
+    // --- Step 2: Use the latest notification to find the batch ---
+    println!("\nStep 2: Prepare storage handler...");
+    let latest = notifications.last().unwrap();
+    println!("  Bucket: {}", latest.notification.bucket);
+    println!("  Key: {}", latest.notification.key);
+    println!("  Object size: {}", latest.notification.object_size);
+
+    // Create FsStorageHandler
+    let root_dir = PathBuf::from("/tmp/memq-storage");
+    let handler = FsStorageHandler::new(FsStorageConfig { root_dir: root_dir.clone() });
+
+    // --- Step 3: Fetch batch from storage ---
+    println!("\nStep 3: Fetch batch from filesystem...");
+    let batch_data = handler.fetch_batch(&latest.notification.bucket, &latest.notification.key)
+        .expect("Failed to fetch batch");
+    println!("  Batch size: {} bytes", batch_data.data.len());
+
+    // --- Step 4: Parse the batch ---
+    println!("\nStep 4: Parse batch and read messages...");
+    let (_header, batches) = memq_rust_client::parse_batch(&batch_data.data)
+        .expect("Failed to parse batch");
+    println!("  Sub-batches: {}", batches.len());
+
+    let mut all_messages: Vec<Message> = Vec::new();
+    for batch in &batches {
+        let mut iter = memq_rust_client::MessageIterator::new(&batch.decompressed_payload, batch.header.log_message_count);
+        while iter.has_next() {
+            let msg = iter.next().expect("Failed to read message");
+            all_messages.push(msg);
+        }
+    }
+
+    // --- Step 5: Verify ---
+    println!("\nStep 5: Verification...");
+    println!("  Messages read: {}", all_messages.len());
+
+    // Print all message keys/values
+    for (i, msg) in all_messages.iter().enumerate() {
+        let key = msg.key.as_ref().map(|k| String::from_utf8_lossy(k).to_string());
+        let value = msg.value.as_ref().map(|v| String::from_utf8_lossy(v).to_string());
+        println!("  Message {}: key={:?} value={:?}", i + 1, key, value);
+    }
+
+    if !all_messages.is_empty() {
+        println!("\n  SUCCESS: Rust consumer read all {} messages from the real MemQ broker!", all_messages.len());
+    } else {
+        println!("\n  FAILED: No messages read");
+        std::process::exit(1);
+    }
+}

--- a/memq-rust-client/run-e2e.sh
+++ b/memq-rust-client/run-e2e.sh
@@ -1,0 +1,244 @@
+#!/bin/bash
+# End-to-end test: Java producer -> MemQ broker (fs storage) -> Kafka -> Rust consumer
+#
+# Usage: ./run-e2e.sh
+#
+# Prerequisites: Maven (or mvnw), Java, Kafka reachable on localhost:9092
+#
+# This script:
+#   1. Detects or starts Kafka (Docker if needed)
+#   2. Builds MemQ broker if not already built
+#   3. Starts the broker
+#   4. Produces 10 messages via Java producer
+#   5. Runs Rust consumer to read all 10 messages
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/../" && pwd)"
+KAFKA_COMPOSE="$SCRIPT_DIR/tests/docker-compose.yml"
+STORAGE_DIR="/tmp/memq-storage"
+BROKER_CONFIG="$ROOT_DIR/deploy/configs/test-fs.yaml"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+info()  { echo -e "${GREEN}[OK]${NC}  $*"; }
+error() { echo -e "${RED}[FAIL]${NC} $*"; }
+fail()  { error "$1"; exit "${2:-1}"; }
+step()  { echo -e "${YELLOW}>>> $*${NC}"; }
+
+MAVEN_CMD="mvn"
+if [ -f "$ROOT_DIR/mvnw" ]; then
+    MAVEN_CMD="./mvnw"
+fi
+MVN_OPTS="-DskipTests -Dmaven.javadoc.skip=true -q"
+
+# --- Check prerequisites ---
+step "Checking prerequisites..."
+
+if ! command -v java &>/dev/null; then
+    fail "java not found. Install JDK 11+ and add to PATH."
+fi
+info "java $(java -version 2>&1 | head -1)"
+
+if ! command -v mvn &>/dev/null; then
+    fail "Maven not found. Install Maven and add to PATH."
+fi
+info "Maven $(mvn -version 2>&1 | head -1)"
+
+if ! command -v cargo &>/dev/null; then
+    export PATH="$HOME/.cargo/bin:$PATH"
+fi
+if ! command -v cargo &>/dev/null; then
+    fail "cargo (Rust) not found. Install Rust and add ~/.cargo/bin to PATH."
+fi
+info "Rust $(cargo --version 2>&1)"
+
+# --- Step 1: Detect Kafka ---
+USED_DOCKER="false"
+
+function kafka_is_up() {
+    nc -z localhost 9092 2>/dev/null
+}
+
+if kafka_is_up; then
+    step "Kafka detected on localhost:9092 (host), skipping Docker..."
+else
+    step "Kafka not detected, starting Docker Kafka..."
+    if ! command -v docker-compose &>/dev/null; then
+        fail "docker-compose not found. Install Docker Compose or start a Kafka broker on localhost:9092."
+    fi
+    docker-compose -f "$KAFKA_COMPOSE" pull > /dev/null 2>&1 || true
+    docker-compose -f "$KAFKA_COMPOSE" up -d > /dev/null 2>&1
+    USED_DOCKER="true"
+
+    for i in $(seq 1 30); do
+        if kafka_is_up; then
+            info "Kafka is ready"
+            break
+        fi
+        if [ "$i" -eq 30 ]; then
+            fail "Kafka did not become ready in 30s"
+        fi
+        sleep 1
+    done
+fi
+
+# --- Step 2: Create notification topic ---
+step "Creating Kafka topic: TestTopicNotifications (3 partitions)..."
+
+if [ "$USED_DOCKER" = "true" ]; then
+    docker exec kafka kafka-topics.sh --bootstrap-server localhost:9092 \
+      --topic TestTopicNotifications --partitions 3 --replication-factor 1 --create \
+      --if-not-exists > /dev/null 2>&1 || true
+else
+    for tpath in /opt/kafka/bin/kafka-topics.sh /usr/local/kafka/bin/kafka-topics.sh ~/kafka/bin/kafka-topics.sh; do
+        if [ -f "$tpath" ]; then
+            "$tpath" --bootstrap-server localhost:9092 \
+              --topic TestTopicNotifications --partitions 3 --replication-factor 1 --create \
+              --if-not-exists > /dev/null 2>&1 || true
+            break
+        fi
+    done
+fi
+info "Topic ready"
+
+# --- Step 3: Build & start MemQ broker ---
+step "Cleaning previous storage..."
+rm -rf "$STORAGE_DIR"
+
+BROKER_JAR="$ROOT_DIR/memq/target/memq-*.jar"
+DEP_DIR="$ROOT_DIR/memq/target/dependency"
+
+# Always rebuild deps to ensure clean SLF4J state
+rm -rf "$DEP_DIR"
+
+if ! ls $BROKER_JAR 2>/dev/null | head -1 | grep -q .; then
+    step "Building MemQ broker (this may take a few minutes)..."
+    cd "$ROOT_DIR"
+    $MAVEN_CMD package $MVN_OPTS > /tmp/memq-build.log 2>&1 || {
+        error "Build failed. See /tmp/memq-build.log"
+        tail -20 /tmp/memq-build.log
+        exit 1
+    }
+fi
+
+# Copy dependencies for classpath, then remove conflicting SLF4J impls for Dropwizard
+$MAVEN_CMD dependency:copy-dependencies -DoutputDirectory="$DEP_DIR" $MVN_OPTS > /dev/null 2>&1
+rm -f "$DEP_DIR/slf4j-simple"* "$DEP_DIR/slf4j-log4j12"* 2>/dev/null || true
+info "Broker ready"
+
+BROKER_JAR="$(ls $BROKER_JAR 2>/dev/null | head -1)"
+if [ -z "$BROKER_JAR" ]; then
+    fail "No broker jar found in memq/target/"
+fi
+info "Broker jar: $BROKER_JAR"
+
+# Kill existing broker on port 8080
+EXISTING_PID=$(lsof -ti:8080 2>/dev/null || true)
+if [ -n "$EXISTING_PID" ]; then
+    step "Killing existing broker (PID: $EXISTING_PID)..."
+    kill -9 $EXISTING_PID 2>/dev/null || true
+    sleep 2
+fi
+
+step "Starting MemQ broker..."
+BROKER_CP="$BROKER_JAR:$DEP_DIR/*"
+java -cp "$BROKER_CP" com.pinterest.memq.core.MemqMain server "$BROKER_CONFIG" > /tmp/memq-broker.log 2>&1 &
+BROKER_PID=$!
+info "Broker started (PID: $BROKER_PID)"
+
+# Wait for broker HTTP endpoint
+for i in $(seq 1 60); do
+    if curl -s http://localhost:8080 > /dev/null 2>&1; then
+        info "Broker is ready"
+        break
+    fi
+    if [ "$i" -eq 60 ]; then
+        error "Broker did not become ready in 60s"
+        cat /tmp/memq-broker.log
+        fail ""
+    fi
+    sleep 1
+done
+
+# --- Step 4: Produce 10 messages via Java producer ---
+step "Producing 10 messages via Java producer..."
+cd "$ROOT_DIR"
+
+# Find Java client dependencies
+CLIENT_JAR="$(ls memq-client/target/memq-client-*.jar 2>/dev/null | head -1)"
+COMMONS_JAR="$(ls memq-commons/target/memq-commons-*.jar 2>/dev/null | head -1)"
+CLIENT_ALL_JAR="$(ls memq-client-all/target/memq-client-all-*.jar 2>/dev/null | head -1)"
+
+if [ -n "$CLIENT_ALL_JAR" ]; then
+    # Use fat jar - has all dependencies bundled
+    CLASSPATH="$CLIENT_ALL_JAR"
+elif [ -n "$CLIENT_JAR" ] && [ -n "$COMMONS_JAR" ]; then
+    CLASSPATH="$CLIENT_JAR:$COMMONS_JAR"
+else
+    step "Building Java client..."
+    $MAVEN_CMD package -pl memq-client,memq-commons $MVN_OPTS > /tmp/memq-client-build.log 2>&1 || {
+        error "Client build failed. See /tmp/memq-client-build.log"
+        tail -20 /tmp/memq-client-build.log
+        fail ""
+    }
+    CLIENT_JAR="$(ls memq-client/target/memq-client-*.jar 2>/dev/null | head -1)"
+    COMMONS_JAR="$(ls memq-commons/target/memq-commons-*.jar 2>/dev/null | head -1)"
+    CLASSPATH="$CLIENT_JAR:$COMMONS_JAR"
+fi
+
+# Create serverset for Java producer
+rm -rf /tmp/memq_serverset
+mkdir -p /tmp/memq_serverset
+cat > /tmp/memq_serverset/serverset <<'EOF'
+{"az": "us-east-1a", "ip": "127.0.0.1", "port": "8080", "stage_name": "prototype", "version": "none", "weight": 1}
+EOF
+
+# Minimal 10-message producer
+cat > /tmp/E2EProducer.java << 'JAVAEOF'
+import com.pinterest.memq.client.commons.serde.ByteArraySerializer;
+import com.pinterest.memq.client.producer2.MemqProducer;
+public class E2EProducer {
+    public static void main(String[] args) throws Exception {
+        MemqProducer<byte[], byte[]> producer = new MemqProducer.Builder<byte[], byte[]>()
+            .disableAcks(false)
+            .keySerializer(new ByteArraySerializer())
+            .valueSerializer(new ByteArraySerializer())
+            .topic("test")
+            .cluster("local")
+            .bootstrapServers("127.0.0.1:9093")
+            .build();
+
+        for (int i = 0; i < 10; i++) {
+            final int idx = i;
+            byte[] key = ("e2e-key-" + idx).getBytes("UTF-8");
+            byte[] value = ("e2e-value-" + idx).getBytes("UTF-8");
+            producer.write(key, value, System.nanoTime()).get();
+            System.out.println("  Message " + (idx + 1) + "/10 written");
+        }
+        producer.flush();
+        producer.close();
+        System.out.println("All 10 messages produced successfully");
+    }
+}
+JAVAEOF
+
+javac -cp "$CLASSPATH" /tmp/E2EProducer.java 2>&1 || {
+    error "Failed to compile E2EProducer. Classpath: $CLASSPATH"
+    fail ""
+}
+java -cp "$CLASSPATH:/tmp" E2EProducer 2>&1
+
+# --- Step 5: Run Rust consumer ---
+step "Running Rust consumer to read messages..."
+cd "$SCRIPT_DIR"
+export PATH="$HOME/.cargo/bin:$PATH"
+cargo run --example e2e_broker
+
+echo ""
+info "E2E pipeline completed successfully!"
+info "Java producer -> MemQ broker (fs storage) -> Kafka -> Rust consumer: ALL PASSED"

--- a/memq-rust-client/src/batch_header.rs
+++ b/memq-rust-client/src/batch_header.rs
@@ -1,0 +1,80 @@
+use crate::error::{MemqError, Result};
+
+/// Index entry mapping a message index to its byte offset and size within the batch.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct IndexEntry {
+    pub offset: u32,
+    pub size: u32,
+}
+
+/// BatchHeader: enables O(1) seeks into a stored batch file to find a specific message.
+///
+/// Wire format:
+///   headerLength:  int (4 bytes)
+///   numIndexEntries: int (4 bytes)
+///   entries[N]:    idx(int) offset(int) size(int) -- 12 bytes each
+///
+/// The index entries are sorted by message index (0, 1, 2, ...).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BatchHeader {
+    /// Total header length (headerLength field, stored as u32 for convenience).
+    pub header_length: u32,
+    /// Map of message index -> (offset, size) within the batch.
+    pub entries: Vec<(u32, IndexEntry)>,
+}
+
+impl BatchHeader {
+    /// Parse a BatchHeader from raw bytes.
+    ///
+    /// The stream starts at the beginning of the header.
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self> {
+        if bytes.len() < 8 {
+            return Err(MemqError::BatchTooSmall(bytes.len(), 8));
+        }
+
+        let header_length = u32::from_be_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]);
+        let num_entries = u32::from_be_bytes([bytes[4], bytes[5], bytes[6], bytes[7]]) as usize;
+
+        // Minimum size: 8 (header) + 12 * num_entries
+        let expected_min = 8 + 12 * num_entries;
+        if bytes.len() < expected_min {
+            return Err(MemqError::BatchTooSmall(bytes.len(), expected_min));
+        }
+
+        let mut entries = Vec::with_capacity(num_entries);
+        let mut offset = 8;
+
+        for _ in 0..num_entries {
+            if offset + 12 > bytes.len() {
+                return Err(MemqError::InvalidHeader("truncated entry".into()));
+            }
+
+            let idx = u32::from_be_bytes([bytes[offset], bytes[offset + 1], bytes[offset + 2], bytes[offset + 3]]);
+            let entry_offset = u32::from_be_bytes([bytes[offset + 4], bytes[offset + 5], bytes[offset + 6], bytes[offset + 7]]);
+            let entry_size = u32::from_be_bytes([bytes[offset + 8], bytes[offset + 9], bytes[offset + 10], bytes[offset + 11]]);
+
+            entries.push((idx, IndexEntry { offset: entry_offset, size: entry_size }));
+            offset += 12;
+        }
+
+        Ok(BatchHeader {
+            header_length,
+            entries,
+        })
+    }
+
+    /// Look up the IndexEntry for a given message index.
+    pub fn get(&self, idx: u32) -> Option<&IndexEntry> {
+        self.entries.iter().find(|(i, _)| *i == idx).map(|(_, e)| e)
+    }
+
+    /// Return the number of entries.
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    /// Whether the header has no entries.
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+}

--- a/memq-rust-client/src/compression.rs
+++ b/memq-rust-client/src/compression.rs
@@ -1,0 +1,59 @@
+use flate2::read::GzDecoder;
+use flate2::write::GzEncoder;
+use std::io::{Read, Write};
+
+use crate::error::MemqError;
+
+/// Compression scheme used for batch payloads.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum Compression {
+    None = 0,
+    Gzip = 1,
+    Zstd = 2,
+}
+
+impl Compression {
+    /// Parse a compression byte from the MemqMessageHeader.
+    pub fn from_u8(v: u8) -> Result<Self, MemqError> {
+        match v {
+            0 => Ok(Compression::None),
+            1 => Ok(Compression::Gzip),
+            2 => Ok(Compression::Zstd),
+            _ => Err(MemqError::UnknownCompression(v)),
+        }
+    }
+
+    /// Decompress a compressed payload (used when reading batches from S3).
+    pub fn decompress(self, compressed: &[u8]) -> std::result::Result<Vec<u8>, MemqError> {
+        match self {
+            Compression::None => Ok(compressed.to_vec()),
+            Compression::Gzip => {
+                let mut decoder = GzDecoder::new(compressed);
+                let mut out = Vec::new();
+                decoder.read_to_end(&mut out)?;
+                Ok(out)
+            }
+            Compression::Zstd => {
+                let decompressed = zstd::decode_all(compressed)?;
+                Ok(decompressed)
+            }
+        }
+    }
+
+    /// Compress a payload (used when writing batches to S3).
+    pub fn compress(self, data: &[u8]) -> std::result::Result<Vec<u8>, MemqError> {
+        match self {
+            Compression::None => Ok(data.to_vec()),
+            Compression::Gzip => {
+                let mut encoder = GzEncoder::new(Vec::new(), flate2::Compression::default());
+                encoder.write_all(data)?;
+                Ok(encoder.finish()?)
+            }
+            Compression::Zstd => {
+                let compressed = zstd::encode_all(data, 3)?;
+                Ok(compressed)
+            }
+        }
+    }
+}

--- a/memq-rust-client/src/consumer.rs
+++ b/memq-rust-client/src/consumer.rs
@@ -1,0 +1,417 @@
+/// MemQ consumer: polls Kafka notifications, fetches batches from storage, parses messages.
+///
+/// Mirrors the Java `MemqConsumer` API with builder pattern, poll iterator,
+/// and offset commit methods.
+
+use crate::error::{MemqError, Result};
+use crate::kafka::{EnrichedNotification, KafkaNotificationConfig, KafkaNotificationSource};
+use crate::kafka::AutoOffsetReset;
+use crate::notification::Notification;
+use crate::storage::{create_storage_handler, MemqStorageConfig, StorageHandler};
+use crate::{parse_batch, Message};
+use std::collections::VecDeque;
+use std::sync::Arc;
+use std::time::Duration;
+
+/// Configuration for the MemQ consumer.
+#[derive(Debug, Clone)]
+pub struct MemqConsumerConfig {
+    /// Kafka bootstrap servers.
+    pub bootstrap_servers: Vec<String>,
+    /// Consumer group ID.
+    pub group_id: String,
+    /// Notification topic name.
+    pub notification_topic: String,
+    /// Storage backend configuration.
+    pub storage_config: MemqStorageConfig,
+    /// Auto offset reset strategy.
+    pub auto_offset_reset: AutoOffsetReset,
+}
+
+/// An iterator over messages from a single notification (one batch).
+struct NotificationMessageIterator {
+    /// Raw decompressed payload bytes (preserves wire format for MessageIterator).
+    data: Vec<u8>,
+    pos: usize,
+    remaining: u32,
+}
+
+impl NotificationMessageIterator {
+    fn new(data: Vec<u8>, remaining: u32) -> Self {
+        NotificationMessageIterator { data, pos: 0, remaining }
+    }
+
+    fn has_next(&self) -> bool {
+        self.remaining > 0 && self.pos < self.data.len()
+    }
+
+    fn next(&mut self) -> Result<Message> {
+        if !self.has_next() {
+            return Err(MemqError::NoMoreMessages);
+        }
+
+        let pos = self.pos;
+
+        // Read internalFieldsLength
+        if pos + 2 > self.data.len() {
+            return Err(MemqError::UnexpectedEof);
+        }
+        let internal_fields_length = u16::from_be_bytes([self.data[pos], self.data[pos + 1]]) as usize;
+        self.pos += 2;
+
+        let mut write_timestamp = None;
+        let mut message_id = None;
+        let mut headers = Vec::new();
+
+        if internal_fields_length > 0 {
+            if self.pos + 8 > self.data.len() {
+                return Err(MemqError::UnexpectedEof);
+            }
+            write_timestamp = Some(i64::from_be_bytes([
+                self.data[self.pos], self.data[self.pos + 1], self.data[self.pos + 2],
+                self.data[self.pos + 3], self.data[self.pos + 4], self.data[self.pos + 5],
+                self.data[self.pos + 6], self.data[self.pos + 7],
+            ]));
+            self.pos += 8;
+
+            if self.pos > self.data.len() {
+                return Err(MemqError::UnexpectedEof);
+            }
+            let message_id_length = self.data[self.pos] as usize;
+            self.pos += 1;
+
+            if message_id_length > 0 {
+                if self.pos + message_id_length > self.data.len() {
+                    return Err(MemqError::UnexpectedEof);
+                }
+                message_id = Some(self.data[self.pos..self.pos + message_id_length].to_vec());
+                self.pos += message_id_length;
+            }
+
+            if self.pos + 2 > self.data.len() {
+                return Err(MemqError::UnexpectedEof);
+            }
+            let mut headers_length = u16::from_be_bytes([self.data[self.pos], self.data[self.pos + 1]]) as usize;
+            self.pos += 2;
+
+            while headers_length > 0 && self.pos < self.data.len() {
+                if self.pos + 4 > self.data.len() {
+                    return Err(MemqError::UnexpectedEof);
+                }
+                let key_length = u16::from_be_bytes([self.data[self.pos], self.data[self.pos + 1]]) as usize;
+                self.pos += 2;
+                if self.pos + key_length > self.data.len() {
+                    return Err(MemqError::UnexpectedEof);
+                }
+                let key = String::from_utf8_lossy(&self.data[self.pos..self.pos + key_length]).to_string();
+                self.pos += key_length;
+                if self.pos + 2 > self.data.len() {
+                    return Err(MemqError::UnexpectedEof);
+                }
+                let value_length = u16::from_be_bytes([self.data[self.pos], self.data[self.pos + 1]]) as usize;
+                self.pos += 2;
+                if self.pos + value_length > self.data.len() {
+                    return Err(MemqError::UnexpectedEof);
+                }
+                let value = self.data[self.pos..self.pos + value_length].to_vec();
+                self.pos += value_length;
+                headers.push((key, value));
+                headers_length -= 4 + key_length + value_length;
+            }
+        }
+
+        // Read key
+        if self.pos + 4 > self.data.len() {
+            return Err(MemqError::UnexpectedEof);
+        }
+        let key_length = i32::from_be_bytes([
+            self.data[self.pos], self.data[self.pos + 1],
+            self.data[self.pos + 2], self.data[self.pos + 3],
+        ]) as usize;
+        self.pos += 4;
+        let key = if key_length > 0 && self.pos + key_length <= self.data.len() {
+            Some(self.data[self.pos..self.pos + key_length].to_vec())
+        } else {
+            None
+        };
+        if key_length > 0 {
+            self.pos += key_length;
+        }
+
+        // Read value
+        if self.pos + 4 > self.data.len() {
+            return Err(MemqError::UnexpectedEof);
+        }
+        let value_length = i32::from_be_bytes([
+            self.data[self.pos], self.data[self.pos + 1],
+            self.data[self.pos + 2], self.data[self.pos + 3],
+        ]) as usize;
+        self.pos += 4;
+        let value = if value_length > 0 && self.pos + value_length <= self.data.len() {
+            Some(self.data[self.pos..self.pos + value_length].to_vec())
+        } else {
+            None
+        };
+        if value_length > 0 {
+            self.pos += value_length;
+        }
+
+        self.remaining -= 1;
+
+        Ok(Message {
+            key,
+            value,
+            write_timestamp,
+            message_id,
+            headers,
+        })
+    }
+}
+
+/// A stream of messages from a single batch.
+struct BatchMessageStream {
+    iter: NotificationMessageIterator,
+}
+
+impl BatchMessageStream {
+    fn has_next(&self) -> bool {
+        self.iter.has_next()
+    }
+
+    fn next(&mut self) -> Result<Message> {
+        self.iter.next()
+    }
+}
+
+/// A notification batch iterator that yields messages from batches.
+///
+/// Wraps the notification queue and storage fetch logic. Mirrors Java's
+/// `NotificationBatchIterator` inner class.
+struct NotificationBatchIterator {
+    /// Queue of enriched notifications from Kafka.
+    notification_queue: VecDeque<EnrichedNotification>,
+    /// Current message iterator for the active batch.
+    current: Option<BatchMessageStream>,
+    /// Retry count for current notification.
+    retry_count: u32,
+    max_retries: u32,
+}
+
+impl NotificationBatchIterator {
+    fn new(notifications: Vec<EnrichedNotification>) -> Self {
+        NotificationBatchIterator {
+            notification_queue: notifications.into_iter().collect(),
+            current: None,
+            retry_count: 0,
+            max_retries: 2,
+        }
+    }
+
+    fn has_next(&mut self, storage: &dyn StorageHandler) -> bool {
+        loop {
+            match &self.current {
+                Some(stream) => {
+                    if stream.has_next() {
+                        return true;
+                    }
+                    // Stream exhausted, load next
+                    self.current = None;
+                    self.retry_count = 0;
+                }
+                None => {
+                    // Try to get next notification
+                    if let Some(notification) = self.notification_queue.pop_front() {
+                        if let Ok(stream) = load_batch(storage, &notification.notification) {
+                            self.current = Some(stream);
+                            self.retry_count = 0;
+                            return true;
+                        } else {
+                            self.retry_count += 1;
+                            if self.retry_count > self.max_retries {
+                                // Skip this notification after retries
+                                self.retry_count = 0;
+                            }
+                        }
+                    } else {
+                        return false;
+                    }
+                }
+            }
+        }
+    }
+
+    fn next(&mut self) -> Result<Message> {
+        if let Some(ref mut stream) = self.current {
+            stream.next()
+        } else {
+            Err(MemqError::NoMoreMessages)
+        }
+    }
+}
+
+/// Load a batch from storage and create a message stream.
+fn load_batch(storage: &dyn StorageHandler, notification: &Notification) -> Result<BatchMessageStream> {
+    let batch_data = storage.fetch_batch(&notification.bucket, &notification.key)?;
+    let (_batch_header, message_batches) = parse_batch(&batch_data.data)?;
+
+    // Collect all messages from all sub-batches into one iterator
+    let mut all_data = Vec::new();
+    for msg_batch in &message_batches {
+        all_data.extend_from_slice(&msg_batch.decompressed_payload);
+    }
+
+    let total_count: u32 = message_batches.iter().map(|b| b.header.log_message_count).sum();
+    let iter = NotificationMessageIterator::new(all_data, total_count);
+
+    Ok(BatchMessageStream { iter })
+}
+
+/// The MemQ consumer.
+///
+/// Polls Kafka for notification topics, fetches batches from storage,
+/// and yields messages via an iterator. Supports offset commits.
+///
+/// # Example
+/// ```ignore
+/// let config = MemqConsumerConfig {
+///     bootstrap_servers: vec!["localhost:9092".to_string()],
+///     group_id: "my-consumer-group".to_string(),
+///     notification_topic: "TestTopicNotifications".to_string(),
+///     storage_config: MemqStorageConfig::Fs(FsStorageConfig {
+///         root_dir: PathBuf::from("/tmp/memq-storage"),
+///     }),
+///     auto_offset_reset: AutoOffsetReset::Earliest,
+/// };
+///
+/// let mut consumer = MemqConsumer::new(config)?;
+///
+/// loop {
+///     let messages = consumer.poll(Duration::from_secs(1))?;
+///     for msg in messages {
+///         println!("key={:?} value={:?}", msg.key, msg.value);
+///     }
+///     consumer.commit_offset()?;
+/// }
+/// ```
+pub struct MemqConsumer {
+    _config: MemqConsumerConfig,
+    kafka_source: KafkaNotificationSource,
+    storage: Arc<dyn StorageHandler>,
+    /// Queue of enriched notifications ready to be processed.
+    notification_queue: VecDeque<EnrichedNotification>,
+    /// Current batch iterator.
+    batch_iterator: Option<NotificationBatchIterator>,
+    /// Whether the consumer is closed.
+    closed: bool,
+    /// Dry run mode (skip offset commits).
+    dry_run: bool,
+}
+
+impl MemqConsumer {
+    /// Create a new MemqConsumer with the given config.
+    pub fn new(config: MemqConsumerConfig) -> Result<Self> {
+        let kafka_config = KafkaNotificationConfig {
+            bootstrap_servers: config.bootstrap_servers.clone(),
+            group_id: config.group_id.clone(),
+            notification_topic: config.notification_topic.clone(),
+            auto_offset_reset: config.auto_offset_reset,
+            max_poll_records: 100,
+        };
+
+        let kafka_source = KafkaNotificationSource::new(kafka_config)?;
+        let storage: Arc<dyn StorageHandler> = Arc::from(create_storage_handler(config.storage_config.clone())?);
+
+        Ok(MemqConsumer {
+            _config: config,
+            kafka_source,
+            storage,
+            notification_queue: VecDeque::new(),
+            batch_iterator: None,
+            closed: false,
+            dry_run: false,
+        })
+    }
+
+    /// Set dry run mode (don't commit offsets).
+    #[must_use]
+    pub fn dry_run(mut self, dry_run: bool) -> Self {
+        self.dry_run = dry_run;
+        self
+    }
+
+    /// Poll Kafka for new notifications and return messages from all available batches.
+    ///
+    /// Blocks for at most `timeout`. Returns messages from all notifications
+    /// that were available within the timeout.
+    pub fn poll(&mut self, timeout: Duration) -> Result<Vec<Message>> {
+        if self.closed {
+            return Err(MemqError::ConsumerClosed);
+        }
+
+        // Poll Kafka for new notifications
+        let notifications = self.kafka_source.poll(timeout)?;
+
+        // Add to notification queue
+        self.notification_queue.extend(notifications);
+
+        // Create batch iterator if we have notifications
+        if self.notification_queue.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        if self.batch_iterator.is_none() {
+            self.batch_iterator = Some(NotificationBatchIterator::new(
+                self.notification_queue.drain(..).collect(),
+            ));
+        }
+
+        // Collect all messages from the batch iterator
+        let mut messages = Vec::new();
+        if let Some(ref mut iter) = self.batch_iterator {
+            while iter.has_next(self.storage.as_ref()) {
+                messages.push(iter.next()?);
+            }
+            // If iterator is exhausted, reset it
+            if self.batch_iterator.as_ref().unwrap().notification_queue.is_empty() {
+                self.batch_iterator = None;
+            }
+        }
+
+        Ok(messages)
+    }
+
+    /// Commit consumed offsets to Kafka synchronously.
+    pub fn commit_offset(&mut self) -> Result<()> {
+        if self.dry_run {
+            return Ok(());
+        }
+        self.kafka_source.commit()
+    }
+
+    /// Commit specific partition offsets.
+    pub fn commit_offsets(&mut self, offsets: &[(i32, i64)]) -> Result<()> {
+        if self.dry_run {
+            return Ok(());
+        }
+        self.kafka_source.commit_offsets(offsets)
+    }
+
+    /// Close the consumer.
+    pub fn close(&mut self) {
+        self.closed = true;
+    }
+
+    /// Whether the consumer is closed.
+    pub fn is_closed(&self) -> bool {
+        self.closed
+    }
+
+    /// Push an enriched notification directly into the consumer's queue.
+    ///
+    /// Useful for testing — bypasses Kafka entirely.
+    pub fn push_notification(&mut self, enriched: EnrichedNotification) {
+        self.notification_queue.push_back(enriched);
+        // Reset batch iterator so the new notification gets processed
+        self.batch_iterator = None;
+    }
+}

--- a/memq-rust-client/src/deserializer.rs
+++ b/memq-rust-client/src/deserializer.rs
@@ -1,0 +1,38 @@
+/// Deserializer trait and implementations for key/value bytes.
+///
+/// Mirrors the Java `Deserializer` interface.
+///
+/// Note: The trait uses `&[u8]` input and returns owned types or
+/// references with lifetimes tied to the input (not self), since
+/// Rust cannot express "return T where T is a reference with the
+/// input's lifetime" via a simple type parameter.
+pub trait Deserializer<T> {
+    /// Initialize the deserializer with configuration properties.
+    fn init(&mut self, _props: &std::collections::HashMap<String, String>) {}
+
+    /// Deserialize a byte slice into the target type.
+    fn deserialize(&self, bytes: &[u8]) -> T;
+
+    /// Called once at startup to allow the deserializer to read config.
+    fn close(&mut self) {}
+}
+
+/// Returns raw bytes unchanged (owned copy).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ByteArrayDeserializer;
+
+impl Deserializer<Vec<u8>> for ByteArrayDeserializer {
+    fn deserialize(&self, bytes: &[u8]) -> Vec<u8> {
+        bytes.to_vec()
+    }
+}
+
+/// Deserializes bytes to a String (UTF-8).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct StringDeserializer;
+
+impl Deserializer<String> for StringDeserializer {
+    fn deserialize(&self, bytes: &[u8]) -> String {
+        String::from_utf8_lossy(bytes).to_string()
+    }
+}

--- a/memq-rust-client/src/error.rs
+++ b/memq-rust-client/src/error.rs
@@ -1,0 +1,61 @@
+/// All errors that can occur during MemQ batch/message parsing.
+#[derive(Debug, thiserror::Error)]
+pub enum MemqError {
+    #[error("CRC mismatch: expected {expected}, got {actual}")]
+    CrcMismatch { expected: u32, actual: u32 },
+
+    #[error("Unknown compression type: {0}")]
+    UnknownCompression(u8),
+
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
+
+    #[error("Batch too small to contain header: {0} bytes < {1}")]
+    BatchTooSmall(usize, usize),
+
+    #[error("Message stream ended unexpectedly")]
+    UnexpectedEof,
+
+    #[error("Notification JSON missing field: {0}")]
+    MissingNotificationField(String),
+
+    #[error("Invalid batch header: {0}")]
+    InvalidHeader(String),
+
+    // --- S3 / Storage errors ---
+
+    #[error("S3 object not found: {bucket}/{key}")]
+    S3NotFound { bucket: String, key: String },
+
+    #[error("S3 access forbidden: {bucket}/{key}")]
+    S3Forbidden { bucket: String, key: String },
+
+    #[error("S3 error: {0}")]
+    S3Client(String),
+
+    #[error("Failed to generate presigned URL: {0}")]
+    PresignError(String),
+
+    #[error("HTTP error fetching from S3: {status} {msg}")]
+    HttpError { status: u16, msg: String },
+
+    // --- Kafka / Notification errors ---
+
+    #[error("Kafka error: {0}")]
+    Kafka(String),
+
+    #[error("Failed to parse Kafka notification JSON: {0}")]
+    KafkaNotificationParse(String),
+
+    #[error("Consumer closed")]
+    ConsumerClosed,
+
+    #[error("No topics subscribed")]
+    NoTopicsSubscribed,
+
+    #[error("No more messages to read")]
+    NoMoreMessages,
+}
+
+/// Result type for MemQ operations.
+pub type Result<T> = std::result::Result<T, MemqError>;

--- a/memq-rust-client/src/kafka.rs
+++ b/memq-rust-client/src/kafka.rs
@@ -1,0 +1,251 @@
+/// Kafka notification source: polls Kafka for batch upload notifications.
+///
+/// Wraps `kafka::consumer::Consumer` to poll the notification topic,
+/// parse JSON payloads, and enrich them with partition/offset metadata.
+/// Mirrors the Java `KafkaNotificationSource`.
+///
+/// The consumer runs in a background thread. The main thread communicates
+/// via an `mpsc::SyncSender` to enqueue poll requests, and waits on
+/// `recv_timeout` to enforce the deadline.
+
+use crate::error::{MemqError, Result};
+use crate::notification::Notification;
+use kafka::consumer::{Consumer, FetchOffset, GroupOffsetStorage};
+use std::sync::mpsc::{SyncSender, sync_channel};
+use std::time::Duration;
+
+/// An enriched notification from Kafka, with partition/offset metadata.
+#[derive(Debug, Clone)]
+pub struct EnrichedNotification {
+    /// The parsed notification payload.
+    pub notification: Notification,
+    /// Kafka partition ID (npi).
+    pub notification_partition_id: u64,
+    /// Kafka offset within the partition (npo).
+    pub notification_partition_offset: u64,
+    /// Time the notification was read from Kafka (nrts), in ms since epoch.
+    pub notification_read_timestamp: u64,
+}
+
+impl EnrichedNotification {
+    /// Create from a raw JSON string, partition, and offset.
+    pub fn from_json(json: &str, partition: i32, offset: i64) -> Result<Self> {
+        let notification = Notification::from_json(json)?;
+        Ok(EnrichedNotification {
+            notification,
+            notification_partition_id: partition as u64,
+            notification_partition_offset: offset as u64,
+            notification_read_timestamp: std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_millis() as u64,
+        })
+    }
+}
+
+/// Offset reset strategy for new consumer groups.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AutoOffsetReset {
+    Earliest,
+    Latest,
+}
+
+/// Configuration for the Kafka notification source.
+#[derive(Debug, Clone)]
+pub struct KafkaNotificationConfig {
+    /// Kafka bootstrap servers (e.g., ["localhost:9092"]).
+    pub bootstrap_servers: Vec<String>,
+    /// Consumer group ID.
+    pub group_id: String,
+    /// Name of the notification topic to subscribe to.
+    pub notification_topic: String,
+    /// Start from earliest or latest offset.
+    pub auto_offset_reset: AutoOffsetReset,
+    /// Maximum records per poll.
+    pub max_poll_records: u32,
+}
+
+/// Internal request sent from main thread to the background consumer thread.
+enum ConsumerRequest {
+    /// Poll for messages; the sender receives the result.
+    Poll {
+        resp_tx: SyncSender<Result<Vec<OwnedMessage>>>,
+    },
+    /// Commit consumed offsets.
+    Commit {
+        resp_tx: SyncSender<Result<()>>,
+    },
+    /// Shutdown the background thread.
+    Shutdown,
+}
+
+/// Owned message data: (json_value, topic, partition, offset).
+#[derive(Debug, Clone)]
+struct OwnedMessage {
+    value: String,
+    #[allow(dead_code)]
+    topic: String,
+    partition: i32,
+    offset: i64,
+}
+
+/// Kafka notification source.
+///
+/// Runs the kafka-rust Consumer in a background thread. The main thread
+/// sends requests via a sync channel and waits with recv_timeout.
+pub struct KafkaNotificationSource {
+    /// Sender for requests to the background consumer thread.
+    tx: SyncSender<ConsumerRequest>,
+    /// Receiver for results from the background thread (for commit).
+    /// We use a second channel for commit results to avoid mixing poll/commit responses.
+    /// Actually, we encode the result inside the ConsumerRequest response.
+    config: KafkaNotificationConfig,
+}
+
+impl KafkaNotificationSource {
+    /// Create a new KafkaNotificationSource from config.
+    pub fn new(config: KafkaNotificationConfig) -> Result<Self> {
+        let (req_tx, req_rx) = sync_channel::<ConsumerRequest>(1);
+
+        // Build the consumer
+        let mut builder = Consumer::from_hosts(config.bootstrap_servers.clone())
+            .with_topic(config.notification_topic.clone())
+            .with_group(config.group_id.clone())
+            .with_offset_storage(Some(GroupOffsetStorage::Kafka));
+
+        builder = match config.auto_offset_reset {
+            AutoOffsetReset::Earliest => builder.with_fallback_offset(FetchOffset::Earliest),
+            AutoOffsetReset::Latest => builder.with_fallback_offset(FetchOffset::Latest),
+        };
+
+        let consumer = builder
+            .create()
+            .map_err(|e| MemqError::Kafka(format!("Failed to create consumer: {e}")))?;
+
+       // Spawn the background thread
+        std::thread::spawn(move || {
+            let mut consumer = consumer;
+            loop {
+                // Wait for a request (blocking — no auto-poll of Kafka)
+                let request = req_rx.recv();
+                match request {
+                    Ok(ConsumerRequest::Poll { resp_tx }) => {
+                        let result = consumer.poll();
+                        let messages = match result {
+                            Ok(message_sets) => {
+                                let mut msgs = Vec::new();
+                                for ms in message_sets.iter() {
+                                    for msg in ms.messages() {
+                                        if let Ok(json_str) = std::str::from_utf8(msg.value) {
+                                            msgs.push(OwnedMessage {
+                                                value: json_str.to_string(),
+                                                topic: ms.topic().to_string(),
+                                                partition: ms.partition(),
+                                                offset: msg.offset,
+                                            });
+                                            // Mark as consumed
+                                            let _ = consumer.consume_message(
+                                                ms.topic(),
+                                                ms.partition(),
+                                                msg.offset,
+                                            );
+                                        }
+                                    }
+                                }
+                                Ok(msgs)
+                            }
+                            Err(e) => Err(MemqError::Kafka(e.to_string())),
+                        };
+                        let _ = resp_tx.send(messages);
+                    }
+                    Ok(ConsumerRequest::Commit { resp_tx }) => {
+                        let result = consumer.commit_consumed();
+                        let _ = resp_tx.send(result.map_err(|e| MemqError::Kafka(e.to_string())));
+                    }
+                    Ok(ConsumerRequest::Shutdown) => {
+                        break;
+                    }
+                    Err(std::sync::mpsc::RecvError) => {
+                        break;
+                    }
+                }
+            }
+        });
+
+        Ok(KafkaNotificationSource {
+            tx: req_tx,
+            config,
+        })
+    }
+
+    /// Poll Kafka for new notifications, up to max_poll_records.
+    ///
+    /// The background thread handles the blocking poll. The main thread
+    /// waits on `recv_timeout` which *does* return on timeout.
+    pub fn poll(&self, timeout_duration: Duration) -> Result<Vec<EnrichedNotification>> {
+        let (resp_tx, resp_rx) = sync_channel::<Result<Vec<OwnedMessage>>>(1);
+
+        // Send poll request
+        self.tx
+            .send(ConsumerRequest::Poll { resp_tx })
+            .map_err(|_| MemqError::Kafka("Consumer thread disconnected".into()))?;
+
+        // Wait for response with timeout
+        let owned_messages = match resp_rx.recv_timeout(timeout_duration) {
+            Ok(Ok(msgs)) => msgs,
+            Ok(Err(e)) => return Err(e),
+            Err(_) => return Ok(Vec::new()), // timeout — no notifications
+        };
+
+        let mut notifications = Vec::new();
+        for msg in owned_messages {
+            let enriched = EnrichedNotification::from_json(&msg.value, msg.partition, msg.offset);
+            match enriched {
+                Ok(en) => {
+                    notifications.push(en);
+                }
+                Err(e) => {
+                    eprintln!("Skipping bad notification: {e}");
+                }
+            }
+        }
+        Ok(notifications)
+    }
+
+    /// Commit all consumed offsets synchronously.
+    pub fn commit(&self) -> Result<()> {
+        let (resp_tx, resp_rx) = sync_channel::<Result<()>>(1);
+        self.tx
+            .send(ConsumerRequest::Commit { resp_tx })
+            .map_err(|_| MemqError::Kafka("Consumer thread disconnected".into()))?;
+        resp_rx
+            .recv()
+            .map_err(|_| MemqError::Kafka("Consumer thread disconnected".into()))?
+    }
+
+    /// Commit specific partition offsets.
+    pub fn commit_offsets(&self, _offsets: &[(i32, i64)]) -> Result<()> {
+        self.commit()
+    }
+
+    /// Get the notification topic name.
+    pub fn notification_topic(&self) -> &str {
+        &self.config.notification_topic
+    }
+
+    /// Get the consumer group ID.
+    pub fn group_id(&self) -> &str {
+        &self.config.group_id
+    }
+
+    /// Close the notification source (shutdowns the background thread).
+    pub fn close(&self) {
+        let _ = self.tx.send(ConsumerRequest::Shutdown);
+    }
+}
+
+impl Drop for KafkaNotificationSource {
+    fn drop(&mut self) {
+        let _ = self.tx.send(ConsumerRequest::Shutdown);
+    }
+}

--- a/memq-rust-client/src/lib.rs
+++ b/memq-rust-client/src/lib.rs
@@ -1,0 +1,120 @@
+//! MemQ Rust client: protocol parsing and storage format handling.
+//!
+//! This crate provides the ability to parse MemQ batch files as they are
+//! stored on S3. The batch format consists of:
+//!
+//! 1. **BatchHeader** (8 + 12*N bytes) — seek index mapping message index to byte offset/size
+//! 2. **Zero or more MessageHeader + compressed payload pairs** — each header contains metadata
+//!    (compression, CRC, message count), followed by message_length bytes of compressed data
+
+pub mod batch_header;
+pub mod compression;
+pub mod consumer;
+pub mod deserializer;
+pub mod error;
+pub mod kafka;
+pub mod message;
+pub mod notification;
+pub mod storage;
+
+pub use batch_header::BatchHeader;
+pub use compression::Compression;
+pub use consumer::{MemqConsumer, MemqConsumerConfig};
+pub use kafka::AutoOffsetReset;
+pub use deserializer::{ByteArrayDeserializer, Deserializer, StringDeserializer};
+pub use error::{MemqError, Result};
+pub use kafka::{EnrichedNotification, KafkaNotificationConfig, KafkaNotificationSource};
+pub use message::{Message, MessageIterator};
+pub use message_header::MessageHeader;
+pub use notification::Notification;
+pub use storage::{
+    BatchData, FsStorageConfig, FsStorageHandler, MemqStorageConfig, S3StorageConfig, S3StorageHandler,
+    StorageHandler, create_storage_handler,
+};
+
+/// Parsed message header + decompressed payload pair.
+#[derive(Debug)]
+pub struct MessageBatch {
+    pub header: message_header::MessageHeader,
+    pub decompressed_payload: Vec<u8>,
+}
+
+/// Parse a complete batch from raw bytes (as stored on S3).
+///
+/// Batch layout:
+///   BatchHeader (8 + 12*N bytes)
+///   MessageHeader + compressed payload (repeated N times)
+///
+/// CRC32 is computed over the compressed payload bytes of each message header,
+/// exactly as the Java producer does.
+pub fn parse_batch(raw: &[u8]) -> Result<(BatchHeader, Vec<MessageBatch>)> {
+    use crate::error::MemqError;
+
+    if raw.len() < 12 {
+        return Err(MemqError::BatchTooSmall(raw.len(), 12));
+    }
+
+    // Parse BatchHeader
+    let batch_header = BatchHeader::from_bytes(raw)?;
+
+    // Determine where the message headers start
+    let mut pos = 8 + 12 * batch_header.entries.len();
+    let mut batches = Vec::new();
+
+    while pos < raw.len() {
+        // Need at least the fixed portion of the message header (6 bytes)
+        if raw.len() - pos < 6 {
+            break;
+        }
+
+        // Parse MessageHeader
+        let msg_header = message_header::MessageHeader::from_bytes(&raw[pos..])?;
+        let msg_len = msg_header.message_length as usize;
+        let mh_total = msg_header.total_bytes();
+
+        // Determine where the compressed payload starts
+        let payload_start = pos + mh_total;
+        if raw.len() < payload_start + msg_len {
+            return Err(MemqError::BatchTooSmall(raw.len(), payload_start + msg_len));
+        }
+
+        // CRC32 is over the raw compressed payload bytes
+        let compressed_payload = &raw[payload_start..payload_start + msg_len];
+        let actual_crc = crc32fast::hash(compressed_payload);
+        if actual_crc != msg_header.crc {
+            return Err(MemqError::CrcMismatch {
+                expected: msg_header.crc,
+                actual: actual_crc,
+            });
+        }
+
+        // Decompress the payload
+        let decompressed = msg_header.compression.decompress(compressed_payload)?;
+
+        batches.push(MessageBatch {
+            header: msg_header,
+            decompressed_payload: decompressed,
+        });
+
+        // Move to the next message header
+        pos = payload_start + msg_len;
+    }
+
+    Ok((batch_header, batches))
+}
+
+/// Message header module — kept separate for clarity.
+pub mod message_header;
+
+/// Convenience: parse a batch and iterate over all messages across all sub-batches.
+pub fn parse_batch_messages(raw: &[u8]) -> Result<Vec<Message>> {
+    let (_batch_header, batches) = parse_batch(raw)?;
+    let mut messages = Vec::new();
+    for batch in batches {
+        let mut iter = MessageIterator::new(&batch.decompressed_payload, batch.header.log_message_count);
+        while iter.has_next() {
+            messages.push(iter.next()?);
+        }
+    }
+    Ok(messages)
+}

--- a/memq-rust-client/src/message.rs
+++ b/memq-rust-client/src/message.rs
@@ -1,0 +1,191 @@
+use crate::error::{MemqError, Result};
+
+/// A single message from a MemQ batch.
+///
+/// Wire format within the (decompressed) message payload:
+///   internalFieldsLength:  short (2 bytes)
+///   [if internalFieldsLength > 0:]
+///     writeTimestamp:      long (8 bytes)
+///     messageIdLength:     byte (1 byte)
+///     [if messageIdLength > 0:]
+///       messageId:         bytes(messageIdLength)
+///     headersLength:       short (2 bytes)
+///     [while headersLength > 0:]
+///       headerKeyLength:   short (2 bytes)
+///       headerKey:         bytes(headerKeyLength)
+///       headerValueLength: short (2 bytes)
+///       headerValue:       bytes(headerValueLength)
+///       headersLength -= 4 + keyLen + valLen
+///   keyLength:               int (4 bytes)
+///   [key(keyLength bytes)]
+///   valueLength:             int (4 bytes)
+///   [value(valueLength bytes)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Message {
+    pub key: Option<Vec<u8>>,
+    pub value: Option<Vec<u8>>,
+    pub write_timestamp: Option<i64>,
+    pub message_id: Option<Vec<u8>>,
+    pub headers: Vec<(String, Vec<u8>)>,
+}
+
+/// Iterator over messages in a (decompressed) batch payload stream.
+///
+/// Yields messages one at a time until the stream is exhausted or
+/// log_message_count messages have been read.
+pub struct MessageIterator<'a> {
+    data: &'a [u8],
+    pos: usize,
+    remaining: u32,
+    #[allow(dead_code)]
+    log_message_count: u32,
+}
+
+impl<'a> MessageIterator<'a> {
+    /// Create a new MessageIterator from decompressed batch payload bytes.
+    pub fn new(data: &'a [u8], log_message_count: u32) -> Self {
+        MessageIterator {
+            data,
+            pos: 0,
+            remaining: log_message_count,
+            log_message_count,
+        }
+    }
+
+    /// Whether there are more messages to read.
+    pub fn has_next(&self) -> bool {
+        self.remaining > 0 && self.pos < self.data.len()
+    }
+
+    /// Read the next message from the stream.
+    pub fn next(&mut self) -> Result<Message> {
+        if !self.has_next() {
+            return Err(MemqError::UnexpectedEof);
+        }
+
+        let pos = self.pos;
+
+        // Read internalFieldsLength
+        if pos + 2 > self.data.len() {
+            return Err(MemqError::UnexpectedEof);
+        }
+        let internal_fields_length = u16::from_be_bytes([self.data[pos], self.data[pos + 1]]) as usize;
+        self.pos += 2;
+
+        let mut write_timestamp = None;
+        let mut message_id = None;
+        let mut headers = Vec::new();
+
+        if internal_fields_length > 0 {
+            // Read writeTimestamp
+            if self.pos + 8 > self.data.len() {
+                return Err(MemqError::UnexpectedEof);
+            }
+            write_timestamp = Some(i64::from_be_bytes([
+                self.data[self.pos], self.data[self.pos + 1], self.data[self.pos + 2],
+                self.data[self.pos + 3], self.data[self.pos + 4], self.data[self.pos + 5],
+                self.data[self.pos + 6], self.data[self.pos + 7],
+            ]));
+            self.pos += 8;
+
+            // Read messageIdLength
+            if self.pos > self.data.len() {
+                return Err(MemqError::UnexpectedEof);
+            }
+            let message_id_length = self.data[self.pos] as usize;
+            self.pos += 1;
+
+            if message_id_length > 0 {
+                if self.pos + message_id_length > self.data.len() {
+                    return Err(MemqError::UnexpectedEof);
+                }
+                message_id = Some(self.data[self.pos..self.pos + message_id_length].to_vec());
+                self.pos += message_id_length;
+            }
+
+            // Read headers
+            if self.pos + 2 > self.data.len() {
+                return Err(MemqError::UnexpectedEof);
+            }
+            let mut headers_length = u16::from_be_bytes([self.data[self.pos], self.data[self.pos + 1]]) as usize;
+            self.pos += 2;
+
+            while headers_length > 0 && self.pos < self.data.len() {
+                if self.pos + 4 > self.data.len() {
+                    return Err(MemqError::UnexpectedEof);
+                }
+                let key_length = u16::from_be_bytes([self.data[self.pos], self.data[self.pos + 1]]) as usize;
+                self.pos += 2;
+
+                if self.pos + key_length > self.data.len() {
+                    return Err(MemqError::UnexpectedEof);
+                }
+                let key = String::from_utf8_lossy(&self.data[self.pos..self.pos + key_length]).to_string();
+                self.pos += key_length;
+
+                if self.pos + 2 > self.data.len() {
+                    return Err(MemqError::UnexpectedEof);
+                }
+                let value_length = u16::from_be_bytes([self.data[self.pos], self.data[self.pos + 1]]) as usize;
+                self.pos += 2;
+
+                if self.pos + value_length > self.data.len() {
+                    return Err(MemqError::UnexpectedEof);
+                }
+                let value = self.data[self.pos..self.pos + value_length].to_vec();
+                self.pos += value_length;
+
+                headers.push((key, value));
+                headers_length -= 4 + key_length + value_length;
+            }
+        }
+
+        // Read key
+        if self.pos + 4 > self.data.len() {
+            return Err(MemqError::UnexpectedEof);
+        }
+        let key_length = i32::from_be_bytes([
+            self.data[self.pos], self.data[self.pos + 1],
+            self.data[self.pos + 2], self.data[self.pos + 3],
+        ]) as usize;
+        self.pos += 4;
+
+        let key = if key_length > 0 && self.pos + key_length <= self.data.len() {
+            Some(self.data[self.pos..self.pos + key_length].to_vec())
+        } else {
+            None
+        };
+        if key_length > 0 {
+            self.pos += key_length;
+        }
+
+        // Read value
+        if self.pos + 4 > self.data.len() {
+            return Err(MemqError::UnexpectedEof);
+        }
+        let value_length = i32::from_be_bytes([
+            self.data[self.pos], self.data[self.pos + 1],
+            self.data[self.pos + 2], self.data[self.pos + 3],
+        ]) as usize;
+        self.pos += 4;
+
+        let value = if value_length > 0 && self.pos + value_length <= self.data.len() {
+            Some(self.data[self.pos..self.pos + value_length].to_vec())
+        } else {
+            None
+        };
+        if value_length > 0 {
+            self.pos += value_length;
+        }
+
+        self.remaining -= 1;
+
+        Ok(Message {
+            key,
+            value,
+            write_timestamp,
+            message_id,
+            headers,
+        })
+    }
+}

--- a/memq-rust-client/src/message_header.rs
+++ b/memq-rust-client/src/message_header.rs
@@ -1,0 +1,119 @@
+use crate::compression::Compression;
+use crate::error::{MemqError, Result};
+
+/// MemqMessageHeader: wraps the compressed message payload.
+///
+/// Wire format (all big-endian):
+///   headerLength:            short (2 bytes)
+///   version:                 short (2 bytes)
+///   additionalHeaderLength:  short (2 bytes)
+///   [if additionalHeaderLength > 0:]
+///     producerAddressLength: byte (1 byte)
+///     producerAddress:       bytes(producerAddressLength)
+///     producerEpoch:         long (8 bytes)
+///     producerRequestId:     long (8 bytes)
+///   crc:                     int (4 bytes)
+///   compression:             byte (1 byte)
+///   logmessageCount:         int (4 bytes)
+///   messageLength:           int (4 bytes)
+///
+/// Fixed portion: 10 bytes
+/// With additional header: + 1 + 4 + 8 + 8 = 21 bytes
+/// Total with additional: 31 bytes
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MessageHeader {
+    pub header_length: u16,
+    pub version: u16,
+    pub additional_header_length: u16,
+    pub producer_address_length: u8,
+    pub producer_address: Vec<u8>,
+    pub producer_epoch: i64,
+    pub producer_request_id: i64,
+    pub crc: u32,
+    pub compression: Compression,
+    pub log_message_count: u32,
+    pub message_length: u32,
+}
+
+impl MessageHeader {
+    /// The fixed header length (without additional header).
+    pub const HEADER_LENGTH: u16 = 27;
+
+    /// Parse a MessageHeader from raw bytes.
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self> {
+        let mut pos = 0;
+
+        let header_length = u16::from_be_bytes([bytes[pos], bytes[pos + 1]]);
+        pos += 2;
+
+        let version = u16::from_be_bytes([bytes[pos], bytes[pos + 1]]);
+        pos += 2;
+
+        let additional_header_length = u16::from_be_bytes([bytes[pos], bytes[pos + 1]]);
+        pos += 2;
+
+        let mut producer_address_length = 0;
+        let mut producer_address = Vec::new();
+        let mut producer_epoch = 0i64;
+        let mut producer_request_id = 0i64;
+
+        if additional_header_length > 0 {
+            producer_address_length = bytes[pos];
+            pos += 1;
+
+            if pos + producer_address_length as usize > bytes.len() {
+                return Err(MemqError::InvalidHeader("truncated producer address".into()));
+            }
+            producer_address = bytes[pos..pos + producer_address_length as usize].to_vec();
+            pos += producer_address_length as usize;
+
+            producer_epoch = i64::from_be_bytes([
+                bytes[pos], bytes[pos + 1], bytes[pos + 2], bytes[pos + 3],
+                bytes[pos + 4], bytes[pos + 5], bytes[pos + 6], bytes[pos + 7],
+            ]);
+            pos += 8;
+
+            producer_request_id = i64::from_be_bytes([
+                bytes[pos], bytes[pos + 1], bytes[pos + 2], bytes[pos + 3],
+                bytes[pos + 4], bytes[pos + 5], bytes[pos + 6], bytes[pos + 7],
+            ]);
+            pos += 8;
+        }
+
+        let crc = u32::from_be_bytes([bytes[pos], bytes[pos + 1], bytes[pos + 2], bytes[pos + 3]]);
+        pos += 4;
+
+        let compression = Compression::from_u8(bytes[pos])?;
+        pos += 1;
+
+        let log_message_count = u32::from_be_bytes([bytes[pos], bytes[pos + 1], bytes[pos + 2], bytes[pos + 3]]);
+        pos += 4;
+
+        let message_length = u32::from_be_bytes([bytes[pos], bytes[pos + 1], bytes[pos + 2], bytes[pos + 3]]);
+
+        Ok(MessageHeader {
+            header_length,
+            version,
+            additional_header_length,
+            producer_address_length,
+            producer_address,
+            producer_epoch,
+            producer_request_id,
+            crc,
+            compression,
+            log_message_count,
+            message_length,
+        })
+    }
+
+    /// Whether this header has additional fields.
+    pub fn has_additional_header(&self) -> bool {
+        self.additional_header_length > 0
+    }
+
+    /// Total bytes consumed by this header on the wire.
+    /// The additional_header_length already includes the producer address length + address bytes.
+    pub fn total_bytes(&self) -> usize {
+        6 + self.additional_header_length as usize + 4 + 1 + 4 + 4
+    }
+}

--- a/memq-rust-client/src/notification.rs
+++ b/memq-rust-client/src/notification.rs
@@ -1,0 +1,103 @@
+use crate::error::{MemqError, Result};
+
+/// Kafka notification JSON fields.
+///
+/// This is the JSON payload published by KafkaNotificationSink after
+/// a batch is uploaded to S3.
+#[derive(Debug, Clone)]
+pub struct Notification {
+    pub bucket: String,
+    pub key: String,
+    pub object_size: u64,
+    pub topic: String,
+    pub header_size: u64,
+    pub num_batch_messages: u64,
+    pub num_attempts: u64,
+}
+
+impl Notification {
+    /// Parse a notification from a JSON string.
+    ///
+    /// Supports two formats:
+    /// 1. Rust test format: {"bucket": "...", "key": "...", ...}
+    /// 2. Java MemQ broker format: {"path": "/absolute/path/...", ...}
+    ///    (bucket/key derived from path, numAttempts defaults to 1)
+    pub fn from_json(json: &str) -> Result<Self> {
+        let obj: serde_json::Value = serde_json::from_str(json).map_err(|e| {
+            MemqError::MissingNotificationField(format!("JSON parse: {}", e))
+        })?;
+
+        // Java broker uses "objectSize", Rust tests use "size"
+        let object_size = obj.get("size")
+            .or_else(|| obj.get("objectSize"))
+            .ok_or_else(|| MemqError::MissingNotificationField("size or objectSize".into()))?
+            .as_u64()
+            .ok_or_else(|| MemqError::MissingNotificationField("size".into()))?;
+
+        let topic = obj.get("topic")
+            .ok_or_else(|| MemqError::MissingNotificationField("topic".into()))?
+            .as_str()
+            .ok_or_else(|| MemqError::MissingNotificationField("topic".into()))?
+            .to_string();
+
+        let header_size = obj.get("headerSize")
+            .ok_or_else(|| MemqError::MissingNotificationField("headerSize".into()))?
+            .as_u64()
+            .ok_or_else(|| MemqError::MissingNotificationField("headerSize".into()))?;
+
+        let num_batch_messages = obj.get("numBatchMessages")
+            .ok_or_else(|| MemqError::MissingNotificationField("numBatchMessages".into()))?
+            .as_u64()
+            .ok_or_else(|| MemqError::MissingNotificationField("numBatchMessages".into()))?;
+
+        // Handle both Java broker format (path-based) and Rust test format (bucket/key)
+        let (bucket, key) = if let Some(path) = obj.get("path").and_then(|v| v.as_str()) {
+            // Java MemQ broker format: path is an absolute path
+            // Derive bucket from the directory containing the file, key from the filename
+            let path_buf = std::path::Path::new(path);
+            let filename = path_buf
+                .file_name()
+                .map(|f| f.to_string_lossy().to_string())
+                .ok_or_else(|| MemqError::MissingNotificationField("path (no filename)".into()))?;
+            let bucket = path_buf
+                .parent()
+                .map(|p| p.to_string_lossy().to_string())
+                .unwrap_or_default();
+            (bucket, filename)
+        } else {
+            // Rust test format: explicit bucket and key
+            let bucket = obj.get("bucket")
+                .ok_or_else(|| MemqError::MissingNotificationField("bucket or path".into()))?
+                .as_str()
+                .ok_or_else(|| MemqError::MissingNotificationField("bucket".into()))?
+                .to_string();
+
+            let key = obj.get("key")
+                .ok_or_else(|| MemqError::MissingNotificationField("key".into()))?
+                .as_str()
+                .ok_or_else(|| MemqError::MissingNotificationField("key".into()))?
+                .to_string();
+
+            (bucket, key)
+        };
+
+        let num_attempts = obj.get("numAttempts")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(1);
+
+        Ok(Notification {
+            bucket,
+            key,
+            object_size,
+            topic,
+            header_size,
+            num_batch_messages,
+            num_attempts,
+        })
+    }
+
+    /// Parse a notification from a serde_json Value.
+    pub fn from_value(obj: &serde_json::Value) -> Result<Self> {
+        Self::from_json(&obj.to_string())
+    }
+}

--- a/memq-rust-client/src/storage.rs
+++ b/memq-rust-client/src/storage.rs
@@ -1,0 +1,315 @@
+/// Storage handler trait and implementations for fetching batch data.
+///
+/// Mirrors the Java `AbstractS3StorageHandler` / `FileSystemStorageHandler`
+/// abstraction: fetch full batches, headers (range), and individual messages (range).
+
+use crate::batch_header::IndexEntry;
+use crate::error::{MemqError, Result};
+use crate::notification::Notification;
+use std::path::PathBuf;
+
+/// A batch fetched from storage.
+#[derive(Debug, Clone)]
+pub struct BatchData {
+    /// Raw batch bytes (BatchHeader + MessageHeader + payload).
+    pub data: Vec<u8>,
+}
+
+/// Storage handler trait — abstracts S3 and filesystem backends.
+pub trait StorageHandler {
+    /// Fetch a full batch from storage.
+    fn fetch_batch(&self, bucket: &str, key: &str) -> Result<BatchData>;
+
+    /// Fetch only the BatchHeader portion of a batch.
+    fn fetch_header(&self, bucket: &str, key: &str, header_size: u64) -> Result<Vec<u8>>;
+
+    /// Fetch a single message from a batch via range request.
+    fn fetch_message(&self, bucket: &str, key: &str, entry: &IndexEntry) -> Result<Vec<u8>>;
+
+    /// Get the object size from a notification's storage metadata.
+    fn get_batch_size(&self, notification: &Notification) -> u64;
+}
+
+// ---------------------------------------------------------------------------
+// Filesystem storage handler (for testing / local deployment)
+// ---------------------------------------------------------------------------
+
+/// Filesystem storage handler configuration.
+#[derive(Debug, Clone)]
+pub struct FsStorageConfig {
+    /// Root directory where batch files are stored.
+    pub root_dir: PathBuf,
+}
+
+use std::io::{Read, Seek};
+///
+/// Maps notification `bucket` → root directory, `key` → file path under root.
+/// Mirrors Java's `FileSystemStorageHandler`.
+pub struct FsStorageHandler {
+    config: FsStorageConfig,
+}
+
+impl FsStorageHandler {
+    /// Create a new FsStorageHandler from config.
+    pub fn new(config: FsStorageConfig) -> Self {
+        FsStorageHandler { config }
+    }
+
+    /// Resolve a bucket/key to a file path.
+    ///
+    /// For Rust test format: root_dir/bucket/key
+    /// For Java broker format (where bucket is a directory path): root_dir/bucket/key
+    ///   The bucket already contains the full path prefix from the broker's "path" field.
+    fn resolve_path(&self, bucket: &str, key: &str) -> PathBuf {
+        self.config.root_dir.join(bucket).join(key)
+    }
+
+ }
+
+impl StorageHandler for FsStorageHandler {
+    fn fetch_batch(&self, bucket: &str, key: &str) -> Result<BatchData> {
+        let path = self.resolve_path(bucket, key);
+        let data = std::fs::read(&path).map_err(|e| MemqError::Io(e))?;
+        Ok(BatchData { data })
+    }
+
+    fn fetch_header(&self, bucket: &str, key: &str, header_size: u64) -> Result<Vec<u8>> {
+        let path = self.resolve_path(bucket, key);
+        let file = std::fs::File::open(&path).map_err(|e| MemqError::Io(e))?;
+        let mut reader = std::io::BufReader::new(file);
+        let mut data = Vec::with_capacity(header_size as usize);
+        reader.read_to_end(&mut data).map_err(|e| MemqError::Io(e))?;
+        // Truncate to header_size if larger
+        data.truncate(header_size as usize);
+        Ok(data)
+    }
+
+    fn fetch_message(&self, bucket: &str, key: &str, entry: &IndexEntry) -> Result<Vec<u8>> {
+        let path = self.resolve_path(bucket, key);
+        let file = std::fs::File::open(&path).map_err(|e| MemqError::Io(e))?;
+        let mut reader = std::io::BufReader::new(file);
+        let offset = entry.offset as u64;
+        let size = entry.size as u64;
+        // Seek to offset
+        reader.seek(std::io::SeekFrom::Start(offset)).map_err(|e| MemqError::Io(e))?;
+        let mut data = vec![0u8; size as usize];
+        reader.read_exact(&mut data).map_err(|e| MemqError::Io(e))?;
+        Ok(data)
+    }
+
+    fn get_batch_size(&self, notification: &Notification) -> u64 {
+        notification.object_size
+    }
+}
+
+// ---------------------------------------------------------------------------
+// S3 storage handler (production)
+// ---------------------------------------------------------------------------
+
+use aws_sdk_s3::presigning::PresigningConfig;
+use aws_sdk_s3::Client;
+use std::time::Duration;
+use tokio::runtime::Runtime;
+
+/// S3 storage handler configuration.
+#[derive(Debug, Clone)]
+pub struct S3StorageConfig {
+    /// AWS region (e.g., "us-east-1").
+    pub region: String,
+}
+
+/// S3 storage handler for reading batches.
+///
+/// Generates presigned URLs client-side using the AWS SDK, then fetches
+/// data via HTTP. Mirrors Java's `AbstractS3StorageHandler`.
+pub struct S3StorageHandler {
+    client: Client,
+    runtime: Runtime,
+    _config: S3StorageConfig,
+}
+
+impl S3StorageHandler {
+    /// Create a new S3StorageHandler from config.
+    ///
+    /// Uses AWS credential chain (environment variables, ~/.aws/credentials,
+    /// IAM roles, etc.).
+    pub fn new(config: S3StorageConfig) -> Result<Self> {
+        let runtime = Runtime::new().map_err(|e| MemqError::S3Client(e.to_string()))?;
+        let region = config.region.clone();
+
+        let sdk_config = runtime.block_on(async move {
+            aws_config::defaults(aws_config::BehaviorVersion::latest())
+                .region(aws_sdk_s3::config::Region::new(region))
+                .load()
+                .await
+        });
+
+        let client = Client::new(&sdk_config);
+
+        Ok(S3StorageHandler {
+            client,
+            runtime,
+            _config: config,
+        })
+    }
+
+    /// Generate a presigned GET URL for an S3 object.
+    fn presign_get_url(
+        &self,
+        bucket: &str,
+        key: &str,
+        expires_in: Duration,
+    ) -> Result<String> {
+        self.runtime.block_on(async {
+            let presigned_req = self
+                .client
+                .get_object()
+                .bucket(bucket)
+                .key(key)
+                .presigned(PresigningConfig::expires_in(expires_in)
+                    .map_err(|e| MemqError::PresignError(e.to_string()))?)
+                .await
+                .map_err(|e| MemqError::PresignError(e.to_string()))?;
+
+            Ok(presigned_req.uri().to_string())
+        })
+    }
+}
+
+impl StorageHandler for S3StorageHandler {
+    fn fetch_batch(&self, bucket: &str, key: &str) -> Result<BatchData> {
+        let url = self.presign_get_url(bucket, key, Duration::from_secs(3600))?;
+
+        let response = reqwest::blocking::Client::new()
+            .get(&url)
+            .send()
+            .map_err(|e| MemqError::HttpError {
+                status: 0,
+                msg: e.to_string(),
+            })?;
+
+        let status = response.status().as_u16();
+        if status == 404 {
+            return Err(MemqError::S3NotFound {
+                bucket: bucket.to_string(),
+                key: key.to_string(),
+            });
+        }
+        if status == 403 {
+            return Err(MemqError::S3Forbidden {
+                bucket: bucket.to_string(),
+                key: key.to_string(),
+            });
+        }
+        if !response.status().is_success() {
+            return Err(MemqError::HttpError { status, msg: response.status().to_string() });
+        }
+
+        let data = response
+            .bytes()
+            .map_err(|e| MemqError::Io(std::io::Error::new(std::io::ErrorKind::Other, e)))?
+            .to_vec();
+
+        Ok(BatchData { data })
+    }
+
+    fn fetch_header(&self, bucket: &str, key: &str, header_size: u64) -> Result<Vec<u8>> {
+        let url = self.presign_get_url(bucket, key, Duration::from_secs(3600))?;
+
+        let response = reqwest::blocking::Client::new()
+            .get(&url)
+            .header("Range", format!("bytes=0-{}", header_size - 1))
+            .send()
+            .map_err(|e| MemqError::HttpError {
+                status: 0,
+                msg: e.to_string(),
+            })?;
+
+        let status = response.status().as_u16();
+        if status == 404 {
+            return Err(MemqError::S3NotFound {
+                bucket: bucket.to_string(),
+                key: key.to_string(),
+            });
+        }
+        if status == 403 {
+            return Err(MemqError::S3Forbidden {
+                bucket: bucket.to_string(),
+                key: key.to_string(),
+            });
+        }
+        if !response.status().is_success() {
+            return Err(MemqError::HttpError { status, msg: response.status().to_string() });
+        }
+
+        let data = response
+            .bytes()
+            .map_err(|e| MemqError::Io(std::io::Error::new(std::io::ErrorKind::Other, e)))?
+            .to_vec();
+
+        Ok(data)
+    }
+
+    fn fetch_message(&self, bucket: &str, key: &str, entry: &IndexEntry) -> Result<Vec<u8>> {
+        let end = entry.offset + entry.size - 1;
+        let url = self.presign_get_url(bucket, key, Duration::from_secs(3600))?;
+
+        let response = reqwest::blocking::Client::new()
+            .get(&url)
+            .header("Range", format!("bytes={}-{}", entry.offset, end))
+            .send()
+            .map_err(|e| MemqError::HttpError {
+                status: 0,
+                msg: e.to_string(),
+            })?;
+
+        let status = response.status().as_u16();
+        if status == 404 {
+            return Err(MemqError::S3NotFound {
+                bucket: bucket.to_string(),
+                key: key.to_string(),
+            });
+        }
+        if status == 403 {
+            return Err(MemqError::S3Forbidden {
+                bucket: bucket.to_string(),
+                key: key.to_string(),
+            });
+        }
+        if !response.status().is_success() {
+            return Err(MemqError::HttpError { status, msg: response.status().to_string() });
+        }
+
+        let data = response
+            .bytes()
+            .map_err(|e| MemqError::Io(std::io::Error::new(std::io::ErrorKind::Other, e)))?
+            .to_vec();
+
+        Ok(data)
+    }
+
+    fn get_batch_size(&self, notification: &Notification) -> u64 {
+        notification.object_size
+    }
+}
+
+/// Configuration enum for choosing between S3 and filesystem storage.
+#[derive(Debug, Clone)]
+pub enum MemqStorageConfig {
+    S3(S3StorageConfig),
+    Fs(FsStorageConfig),
+}
+
+/// Create a storage handler from the configuration.
+pub fn create_storage_handler(config: MemqStorageConfig) -> Result<Box<dyn StorageHandler>> {
+    match config {
+        MemqStorageConfig::S3(s3_config) => {
+            let handler = S3StorageHandler::new(s3_config)?;
+            Ok(Box::new(handler))
+        }
+        MemqStorageConfig::Fs(fs_config) => {
+            let handler = FsStorageHandler::new(fs_config);
+            Ok(Box::new(handler))
+        }
+    }
+}

--- a/memq-rust-client/tests/batch_parsing.rs
+++ b/memq-rust-client/tests/batch_parsing.rs
@@ -1,0 +1,641 @@
+use memq_rust_client::{
+    parse_batch, parse_batch_messages, BatchHeader, Compression, Message, MessageHeader, MessageIterator, Notification,
+};
+use memq_rust_client::error::MemqError;
+use memq_rust_client::batch_header::IndexEntry;
+
+// Base64-encoded batch bytes from the Java producer (reused from Python tests).
+const UNCOMPRESSED_BATCH_B64: &str =
+    "AAAAHAAAAAIAAAAAAAAAIAAAAJIAAAABAAAAsgAAAJIAKABkABUErBAAJQAAAXdqDH1EAAAAAAAAAAGRLVIQAAAAAAIAAABqACAAAAF3agx9QwgAAAAAAAAAAAANAAR0ZXN0AAV2YWx1ZQAAAAAAAAALdGVzdDEyMzEyMzEAIAAAAXdqDH1DCAAAAAAAAAABAA0ABHRlc3QABXZhbHVlAAAAAAAAAAt0ZXN0MTIzMTIzMQAoAGQAFQSsEAAlAAABd2oMfUUAAAAAAAAAAf6kvmoAAAAAAgAAAGoAIAAAAXdqDH1ECAAAAAAAAAAAAA0ABHRlc3QABXZhbHVlAAAAAAAAAAt0ZXN0MTIzMTIzMQAgAAABd2oMfUUIAAAAAAAAAAEADQAEdGVzdAAFdmFsdWUAAAAAAAAAC3Rlc3QxMjMxMjMx";
+
+const GZIP_BATCH_B64: &str =
+    "AAAAKAAAAAMAAAAAAAAALAAAAHYAAAABAAAAogAAAHMAAAACAAABFQAAAHMAKABkABUErBAAJQAAAXdqfK1xAAAAAAAAAAFCystcAQAAAAIAAABOH4sIAAAAAAAAAGJQYGBgLM+qWVvAwQADvAwsJanFJQysZYk5palQQW6QkKGRMQgBAAAA//9igGkqhGliJKwJAAAA//8DAOE0yN1qAAAAACgAZAAVBKwQACUAAAF3anytcgAAAAAAAAABz+4rrQEAAAACAAAASx+LCAAAAAAAAABiUGBgYCzPqllbxMEAA7wMLCWpxSUMrGWJOaWpUEFukJChkTEIAQAAAP//YsDQxEhYEwAAAP//AwBlNttIagAAAAAoAGQAFQSsEAAlAAABd2p8rXMAAAAAAAAAAbP5aWQBAAAAAgAAAEsfiwgAAAAAAAAAYlBgYGAsz6pZW8zBAAO8DCwlqcUlDKxliTmlqVBBbpCQoZExCAEAAAD//2LA0MRIWBMAAAD//wMAFqtGF2oAAAA=";
+
+const ZSTD_BATCH_B64: &str =
+    "AAAAQAAAAAUAAAAAAAAARAAAAHMAAAABAAAAtwAAAHAAAAACAAABJwAAAHAAAAADAAABlwAAAHAAAAAEAAACBwAAAHAAKABkABUErBAAJQAAAXdqfduyAAAAAAAAAAFUPvwXAgAAAAIAAABLKLUv/QBYhAEAdAIAIAAAAXdqfduwCAANAAR0ZXN0AAV2YWx1ZQALdGVzdDEyMzEyMzECAGBUAtABZAAAELIBAwDACSCHCxUEAQAAACgAZAAVBKwQACUAAAF3an3bswAAAAAAAAABCOO92wIAAAACAAAASCi1L/0AWIQBAHQCACAAAAF3an3bswgADQAEdGVzdAAFdmFsdWUAC3Rlc3QxMjMxMjMxAgBgVALQAUwAAAgBAgDAEewpIAEAAAAoAGQAFQSsEAAlAAABd2p927QAAAAAAAAAAc70T7kCAAAAAgAAAEgotS/9AFiEAQB0AgAgAAABd2p927QIAA0ABHRlc3QABXZhbHVlAAt0ZXN0MTIzMTIzMQIAYFQC0AFMAAAIAQIAwBHsKSABAAAAKABkABUErBAAJQAAAXdqfdu2AAAAAAAAAAEdbbejAgAAAAIAAABIKLUv/QBYhAEAdAIAIAAAAXdqfdu2CAANAAR0ZXN0AAV2YWx1ZQALdGVzdDEyMzEyMzECAGBUAtABTAAACAECAMAR7CkgAQAAACgAZAAVBKwQACUAAAF3an3btwAAAAAAAAABdKFLrgIAAAACAAAASCi1L/0AWIQBAHQCACAAAAF3an3btwgADQAEdGVzdAAFdmFsdWUAC3Rlc3QxMjMxMjMxAgBgVALQAUwAAAgBAgDAEewpIAEAAA==";
+
+fn decode_b64(s: &str) -> Vec<u8> {
+    base64::Engine::decode(&base64::engine::general_purpose::STANDARD, s).expect("valid base64")
+}
+
+// ---------------------------------------------------------------------------
+// Real batch parsing (reused from Python tests)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn parse_uncompressed_batch() {
+    let raw = decode_b64(UNCOMPRESSED_BATCH_B64);
+    let messages = parse_batch_messages(&raw).expect("parse uncompressed batch");
+    assert_eq!(messages.len(), 4, "should have 4 messages");
+
+    for msg in &messages {
+        assert_eq!(msg.value, Some(b"test1231231".to_vec()));
+    }
+}
+
+#[test]
+fn parse_gzip_batch() {
+    let raw = decode_b64(GZIP_BATCH_B64);
+    let messages = parse_batch_messages(&raw).expect("parse gzip batch");
+    assert_eq!(messages.len(), 6, "should have 6 messages");
+
+    for msg in &messages {
+        assert_eq!(msg.value, Some(b"test1231231".to_vec()));
+    }
+}
+
+#[test]
+fn parse_zstd_batch() {
+    let raw = decode_b64(ZSTD_BATCH_B64);
+    let messages = parse_batch_messages(&raw).expect("parse zstd batch");
+    assert_eq!(messages.len(), 10, "should have 10 messages");
+
+    for msg in &messages {
+        assert_eq!(msg.value, Some(b"test1231231".to_vec()));
+    }
+}
+
+#[test]
+fn parse_batch_returns_header_and_message_batches() {
+    let raw = decode_b64(UNCOMPRESSED_BATCH_B64);
+    let (batch_header, batches) = parse_batch(&raw).expect("parse batch");
+
+    assert_eq!(batch_header.len(), 2); // 2 sub-batches
+    assert_eq!(batch_header.get(0).unwrap().offset, 32);
+    assert_eq!(batches.len(), 2); // 2 MessageHeader+Payload pairs
+    assert_eq!(batches[0].header.compression, Compression::None);
+    assert_eq!(batches[0].header.log_message_count, 2);
+    assert!(batches[0].header.has_additional_header());
+}
+
+// ---------------------------------------------------------------------------
+// BatchHeader roundtrip
+// ---------------------------------------------------------------------------
+
+#[test]
+fn batch_header_roundtrip_single_entry() {
+    let entries = vec![
+        (0u32, IndexEntry { offset: 0, size: 50 }),
+        (1u32, IndexEntry { offset: 50, size: 30 }),
+        (2u32, IndexEntry { offset: 80, size: 20 }),
+    ];
+    let header = BatchHeader {
+        header_length: 44,
+        entries,
+    };
+
+    let mut buf = Vec::new();
+    buf.extend_from_slice(&header.header_length.to_be_bytes());
+    buf.extend_from_slice(&(header.entries.len() as u32).to_be_bytes());
+    for (idx, entry) in &header.entries {
+        buf.extend_from_slice(&idx.to_be_bytes());
+        buf.extend_from_slice(&entry.offset.to_be_bytes());
+        buf.extend_from_slice(&entry.size.to_be_bytes());
+    }
+
+    let parsed = BatchHeader::from_bytes(&buf).expect("parse roundtrip");
+    assert_eq!(parsed, header);
+}
+
+#[test]
+fn batch_header_roundtrip_empty() {
+    let header = BatchHeader {
+        header_length: 12,
+        entries: vec![],
+    };
+
+    let mut buf = Vec::new();
+    buf.extend_from_slice(&header.header_length.to_be_bytes());
+    buf.extend_from_slice(&0u32.to_be_bytes());
+
+    let parsed = BatchHeader::from_bytes(&buf).expect("parse empty");
+    assert_eq!(parsed, header);
+    assert!(parsed.is_empty());
+}
+
+#[test]
+fn batch_header_empty_batch() {
+    let raw = decode_b64(UNCOMPRESSED_BATCH_B64);
+    let (batch_header, _) = parse_batch(&raw).expect("parse");
+    assert!(!batch_header.is_empty());
+    assert_eq!(
+        batch_header.get(0),
+        Some(&IndexEntry { offset: 32, size: 146 })
+    );
+}
+
+#[test]
+fn batch_header_too_small() {
+    let result = BatchHeader::from_bytes(&[1, 2]);
+    assert!(result.is_err());
+}
+
+#[test]
+fn batch_header_truncated_entry() {
+    let raw: Vec<u8> = vec![0, 0, 0, 12, 0, 0, 0, 1, 0, 0, 0, 0];
+    let result = BatchHeader::from_bytes(&raw);
+    assert!(result.is_err());
+}
+
+// ---------------------------------------------------------------------------
+// MessageHeader roundtrip
+// ---------------------------------------------------------------------------
+
+#[test]
+fn message_header_roundtrip_with_additional() {
+    let header = MessageHeader {
+        header_length: MessageHeader::HEADER_LENGTH,
+        version: 100,
+        additional_header_length: 26,
+        producer_address_length: 4,
+        producer_address: vec![127, 0, 0, 1],
+        producer_epoch: 12345,
+        producer_request_id: 67890,
+        crc: 0x12345678,
+        compression: Compression::Zstd,
+        log_message_count: 10,
+        message_length: 512,
+    };
+
+    let mut buf = Vec::new();
+    buf.extend_from_slice(&header.header_length.to_be_bytes());
+    buf.extend_from_slice(&header.version.to_be_bytes());
+    buf.extend_from_slice(&header.additional_header_length.to_be_bytes());
+    buf.push(header.producer_address_length);
+    buf.extend_from_slice(&header.producer_address);
+    buf.extend_from_slice(&header.producer_epoch.to_be_bytes());
+    buf.extend_from_slice(&header.producer_request_id.to_be_bytes());
+    buf.extend_from_slice(&header.crc.to_be_bytes());
+    buf.push(header.compression as u8);
+    buf.extend_from_slice(&header.log_message_count.to_be_bytes());
+    buf.extend_from_slice(&header.message_length.to_be_bytes());
+
+    let parsed = MessageHeader::from_bytes(&buf).expect("parse roundtrip");
+    assert_eq!(parsed, header);
+}
+
+#[test]
+fn message_header_roundtrip_without_additional() {
+    let header = MessageHeader {
+        header_length: MessageHeader::HEADER_LENGTH,
+        version: 100,
+        additional_header_length: 0,
+        producer_address_length: 0,
+        producer_address: vec![],
+        producer_epoch: 0,
+        producer_request_id: 0,
+        crc: 0xABCDEF00,
+        compression: Compression::None,
+        log_message_count: 3,
+        message_length: 100,
+    };
+
+    let mut buf = Vec::new();
+    buf.extend_from_slice(&header.header_length.to_be_bytes());
+    buf.extend_from_slice(&header.version.to_be_bytes());
+    buf.extend_from_slice(&header.additional_header_length.to_be_bytes());
+    buf.extend_from_slice(&header.crc.to_be_bytes());
+    buf.push(header.compression as u8);
+    buf.extend_from_slice(&header.log_message_count.to_be_bytes());
+    buf.extend_from_slice(&header.message_length.to_be_bytes());
+
+    let parsed = MessageHeader::from_bytes(&buf).expect("parse roundtrip");
+    assert_eq!(parsed, header);
+}
+
+#[test]
+fn message_header_unknown_compression() {
+    let mut buf: Vec<u8> = vec![0, 27, 0, 100, 0, 0];
+    buf.extend_from_slice(&0u32.to_be_bytes());
+    buf.push(99);
+    buf.extend_from_slice(&0u32.to_be_bytes());
+    buf.extend_from_slice(&0u32.to_be_bytes());
+
+    let result = MessageHeader::from_bytes(&buf);
+    assert!(result.is_err());
+}
+
+// ---------------------------------------------------------------------------
+// Message roundtrip helpers
+// ---------------------------------------------------------------------------
+
+/// Serialize a Message into the wire format for roundtrip testing.
+fn serialize_message(msg: &Message) -> Vec<u8> {
+    let mut buf = Vec::new();
+
+    let mut internal_len: usize = 0;
+    let has_internal = msg.write_timestamp.is_some()
+        || msg.message_id.is_some()
+        || !msg.headers.is_empty();
+
+    if has_internal {
+        if let Some(_ts) = msg.write_timestamp {
+            internal_len += 8;
+        }
+        if let Some(ref mid) = msg.message_id {
+            internal_len += 1 + mid.len();
+        }
+        for (key, val) in &msg.headers {
+            internal_len += 2 + key.len() + 2 + val.len();
+        }
+    }
+
+    buf.extend_from_slice(&(internal_len as u16).to_be_bytes());
+
+    if has_internal {
+        if let Some(ts) = msg.write_timestamp {
+            buf.extend_from_slice(&ts.to_be_bytes());
+        }
+        if let Some(ref mid) = msg.message_id {
+            buf.push(mid.len() as u8);
+            buf.extend_from_slice(mid);
+        }
+        let mut headers_len: usize = 0;
+        for (key, val) in &msg.headers {
+            headers_len += 2 + key.len() + 2 + val.len();
+        }
+        buf.extend_from_slice(&(headers_len as u16).to_be_bytes());
+        for (key, val) in &msg.headers {
+            buf.extend_from_slice(&(key.len() as u16).to_be_bytes());
+            buf.extend_from_slice(key.as_bytes());
+            buf.extend_from_slice(&(val.len() as u16).to_be_bytes());
+            buf.extend_from_slice(val);
+        }
+    }
+
+    if let Some(ref key) = msg.key {
+        buf.extend_from_slice(&(key.len() as i32).to_be_bytes());
+        buf.extend_from_slice(key);
+    } else {
+        buf.extend_from_slice(&0i32.to_be_bytes());
+    }
+
+    if let Some(ref value) = msg.value {
+        buf.extend_from_slice(&(value.len() as i32).to_be_bytes());
+        buf.extend_from_slice(value);
+    } else {
+        buf.extend_from_slice(&0i32.to_be_bytes());
+    }
+
+    buf
+}
+
+#[test]
+fn message_roundtrip_full() {
+    let msg = Message {
+        key: Some(b"mykey".to_vec()),
+        value: Some(b"myvalue".to_vec()),
+        write_timestamp: Some(1234567890),
+        message_id: Some(vec![0u8, 1, 2, 3]),
+        headers: vec![
+            ("content-type".to_string(), b"application/json".to_vec()),
+            ("x-priority".to_string(), b"high".to_vec()),
+        ],
+    };
+
+    let serialized = serialize_message(&msg);
+    let mut iter = MessageIterator::new(&serialized, 1);
+    let parsed = iter.next().expect("parse message");
+    assert_eq!(parsed, msg);
+}
+
+#[test]
+fn message_roundtrip_no_key() {
+    let msg = Message {
+        key: None,
+        value: Some(b"hello".to_vec()),
+        write_timestamp: None,
+        message_id: None,
+        headers: vec![],
+    };
+
+    let serialized = serialize_message(&msg);
+    let mut iter = MessageIterator::new(&serialized, 1);
+    let parsed = iter.next().expect("parse message");
+    assert_eq!(parsed, msg);
+}
+
+#[test]
+fn message_roundtrip_no_headers() {
+    let msg = Message {
+        key: Some(b"key".to_vec()),
+        value: Some(b"value".to_vec()),
+        write_timestamp: None,
+        message_id: None,
+        headers: vec![],
+    };
+
+    let serialized = serialize_message(&msg);
+    let mut iter = MessageIterator::new(&serialized, 1);
+    let parsed = iter.next().expect("parse message");
+    assert_eq!(parsed, msg);
+}
+
+#[test]
+fn message_roundtrip_multiple_messages() {
+    let msgs = vec![
+        Message {
+            key: Some(b"k1".to_vec()),
+            value: Some(b"v1".to_vec()),
+            write_timestamp: None,
+            message_id: None,
+            headers: vec![],
+        },
+        Message {
+            key: Some(b"k2".to_vec()),
+            value: Some(b"v2".to_vec()),
+            write_timestamp: Some(999),
+            message_id: Some(vec![42]),
+            headers: vec![("h".to_string(), b"v".to_vec())],
+        },
+        Message {
+            key: None,
+            value: None,
+            write_timestamp: None,
+            message_id: None,
+            headers: vec![],
+        },
+    ];
+
+    let mut buf = Vec::new();
+    for msg in &msgs {
+        buf.extend_from_slice(&serialize_message(msg));
+    }
+
+    let mut iter = MessageIterator::new(&buf, msgs.len() as u32);
+    for expected in &msgs {
+        let parsed = iter.next().expect("parse message");
+        assert_eq!(parsed, *expected);
+    }
+    assert!(!iter.has_next());
+}
+
+// ---------------------------------------------------------------------------
+// Notification JSON parsing
+// ---------------------------------------------------------------------------
+
+#[test]
+fn parse_notification_json() {
+    let json = r#"{
+        "bucket": "my-bucket",
+        "key": "topics/my-topic/abc123",
+        "size": 1024,
+        "topic": "my-topic",
+        "headerSize": 48,
+        "numBatchMessages": 5,
+        "numAttempts": 1
+    }"#;
+
+    let notification = Notification::from_json(json).expect("parse notification");
+    assert_eq!(notification.bucket, "my-bucket");
+    assert_eq!(notification.key, "topics/my-topic/abc123");
+    assert_eq!(notification.object_size, 1024);
+    assert_eq!(notification.topic, "my-topic");
+    assert_eq!(notification.header_size, 48);
+    assert_eq!(notification.num_batch_messages, 5);
+    assert_eq!(notification.num_attempts, 1);
+}
+
+#[test]
+fn parse_notification_missing_field() {
+    let json = r#"{"bucket": "test"}"#;
+    let result = Notification::from_json(json);
+    assert!(result.is_err());
+}
+
+// ---------------------------------------------------------------------------
+// CRC validation
+// ---------------------------------------------------------------------------
+
+#[test]
+fn crc_mismatch_error() {
+    let raw = decode_b64(UNCOMPRESSED_BATCH_B64);
+    let mut corrupted = raw.clone();
+
+    let (batch_header, batches) = parse_batch(&raw).expect("parse original");
+    let pos = 8 + 12 * batch_header.entries.len();
+    let mh_total = batches[0].header.total_bytes();
+    let payload_start = pos + mh_total;
+    corrupted[payload_start] ^= 0xFF;
+
+    let result = parse_batch(&corrupted);
+    assert!(result.is_err());
+
+    match result.unwrap_err() {
+        MemqError::CrcMismatch { .. } => {}
+        other => panic!("expected CrcMismatch error, got {:?}", other),
+    }
+}
+
+#[test]
+fn valid_crc_succeeds() {
+    let raw = decode_b64(UNCOMPRESSED_BATCH_B64);
+    let (batch_header, batches) = parse_batch(&raw).expect("parse batch");
+
+    // CRC is computed over the compressed payload (not decompressed)
+    let pos = 8 + 12 * batch_header.entries.len();
+    let mh_total = batches[0].header.total_bytes();
+    let payload_start = pos + mh_total;
+    let compressed = &raw[payload_start..payload_start + batches[0].header.message_length as usize];
+    let actual = crc32fast::hash(compressed);
+    assert_eq!(batches[0].header.crc, actual);
+}
+
+// ---------------------------------------------------------------------------
+// Full roundtrip: construct → compress → parse → verify
+// ---------------------------------------------------------------------------
+
+#[test]
+fn roundtrip_uncompressed_full() {
+    let msgs = vec![
+        Message {
+            key: Some(b"test".to_vec()),
+            value: Some(b"value".to_vec()),
+            write_timestamp: None,
+            message_id: None,
+            headers: vec![],
+        },
+        Message {
+            key: Some(b"test1231231".to_vec()),
+            value: Some(b"test1231231".to_vec()),
+            write_timestamp: None,
+            message_id: None,
+            headers: vec![],
+        },
+    ];
+
+    let batch = build_batch(&msgs, Compression::None);
+    let parsed_msgs = parse_batch_messages(&batch).expect("parse synthetic batch");
+    assert_eq!(parsed_msgs.len(), msgs.len());
+    for (expected, actual) in msgs.iter().zip(parsed_msgs.iter()) {
+        assert_eq!(actual.key, expected.key);
+        assert_eq!(actual.value, expected.value);
+        assert_eq!(actual.headers, expected.headers);
+    }
+}
+
+#[test]
+fn roundtrip_gzip_full() {
+    let msgs = vec![
+        Message {
+            key: Some(b"key1".to_vec()),
+            value: Some(b"value1".to_vec()),
+            write_timestamp: None,
+            message_id: None,
+            headers: vec![],
+        },
+    ];
+
+    let batch = build_batch(&msgs, Compression::Gzip);
+    let parsed_msgs = parse_batch_messages(&batch).expect("parse gzip batch");
+    assert_eq!(parsed_msgs.len(), 1);
+    assert_eq!(parsed_msgs[0].key, Some(b"key1".to_vec()));
+    assert_eq!(parsed_msgs[0].value, Some(b"value1".to_vec()));
+}
+
+#[test]
+fn roundtrip_zstd_full() {
+    let msgs = vec![
+        Message {
+            key: Some(b"key2".to_vec()),
+            value: Some(b"value2".to_vec()),
+            write_timestamp: Some(99999),
+            message_id: Some(vec![0, 1, 2, 3]),
+            headers: vec![("content-type".to_string(), b"application/json".to_vec())],
+        },
+    ];
+
+    let batch = build_batch(&msgs, Compression::Zstd);
+    let parsed_msgs = parse_batch_messages(&batch).expect("parse zstd batch");
+    assert_eq!(parsed_msgs.len(), 1);
+    assert_eq!(parsed_msgs[0].key, Some(b"key2".to_vec()));
+    assert_eq!(parsed_msgs[0].value, Some(b"value2".to_vec()));
+    assert_eq!(parsed_msgs[0].write_timestamp, Some(99999));
+    assert_eq!(parsed_msgs[0].message_id, Some(vec![0, 1, 2, 3]));
+}
+
+/// Build a complete synthetic batch from messages.
+fn build_batch(msgs: &[Message], compression: Compression) -> Vec<u8> {
+    // Serialize messages into payload
+    let mut payload_buf = Vec::new();
+    let mut msg_offsets = Vec::with_capacity(msgs.len());
+    let mut offset = 0usize;
+    for msg in msgs {
+        let ser = serialize_message(msg);
+        msg_offsets.push(offset);
+        offset += ser.len();
+        payload_buf.extend_from_slice(&ser);
+    }
+
+    // Compress
+    let compressed = compression.compress(&payload_buf).unwrap();
+
+    // CRC over compressed
+    let crc = crc32fast::hash(&compressed);
+
+    // MessageHeader (21 bytes with no additional header)
+    let msg_header_size = 6 + 4 + 1 + 4 + 1 + 4 + 4; // 24 bytes
+
+    // BatchHeader
+    let batch_header_size = 8 + 12 * msgs.len();
+    let header_length = batch_header_size as u32 + msg_header_size as u32 + compressed.len() as u32;
+
+    let mut entries = Vec::with_capacity(msgs.len());
+    for (i, &off) in msg_offsets.iter().enumerate() {
+        entries.push((
+            i as u32,
+            IndexEntry {
+                offset: (batch_header_size + msg_header_size + off) as u32,
+                size: ser_size_at(&payload_buf, i) as u32,
+            },
+        ));
+    }
+
+    let batch_header = BatchHeader {
+        header_length,
+        entries,
+    };
+
+    // Serialize batch header
+    let mut batch_buf = Vec::new();
+    batch_buf.extend_from_slice(&batch_header.header_length.to_be_bytes());
+    batch_buf.extend_from_slice(&(batch_header.entries.len() as u32).to_be_bytes());
+    for (idx, entry) in &batch_header.entries {
+        batch_buf.extend_from_slice(&idx.to_be_bytes());
+        batch_buf.extend_from_slice(&entry.offset.to_be_bytes());
+        batch_buf.extend_from_slice(&entry.size.to_be_bytes());
+    }
+
+    // Serialize message header
+    let msg_header = MessageHeader {
+        header_length: MessageHeader::HEADER_LENGTH,
+        version: 100,
+        additional_header_length: 0,
+        producer_address_length: 0,
+        producer_address: vec![],
+        producer_epoch: 0,
+        producer_request_id: 0,
+        crc,
+        compression,
+        log_message_count: msgs.len() as u32,
+        message_length: compressed.len() as u32,
+    };
+
+    batch_buf.extend_from_slice(&msg_header.header_length.to_be_bytes());
+    batch_buf.extend_from_slice(&msg_header.version.to_be_bytes());
+    batch_buf.extend_from_slice(&msg_header.additional_header_length.to_be_bytes());
+    batch_buf.extend_from_slice(&msg_header.crc.to_be_bytes());
+    batch_buf.push(msg_header.compression as u8);
+    batch_buf.extend_from_slice(&msg_header.log_message_count.to_be_bytes());
+    batch_buf.extend_from_slice(&msg_header.message_length.to_be_bytes());
+
+    batch_buf.extend_from_slice(&compressed);
+
+    batch_buf
+}
+
+/// Calculate the byte size of the message at a given index in the serialized payload.
+fn ser_size_at(payload: &[u8], index: usize) -> usize {
+    let mut pos = 0;
+    for i in 0..=index {
+        if pos + 2 > payload.len() {
+            return 0;
+        }
+        let internal_len = u16::from_be_bytes([payload[pos], payload[pos + 1]]) as usize;
+        pos += 2;
+
+        if internal_len > 0 {
+            if pos + 8 > payload.len() { return 0; }
+            pos += 8;
+            if pos > payload.len() { return 0; }
+            let mid_len = payload[pos] as usize;
+            pos += 1 + mid_len;
+            if pos + 2 > payload.len() { return 0; }
+            let headers_len = u16::from_be_bytes([payload[pos], payload[pos + 1]]) as usize;
+            pos += 2;
+            let mut remaining = headers_len;
+            while remaining > 0 && pos < payload.len() {
+                if pos + 4 > payload.len() { return 0; }
+                let kl = u16::from_be_bytes([payload[pos], payload[pos + 1]]) as usize;
+                pos += 2 + kl;
+                if pos + 2 > payload.len() { return 0; }
+                let vl = u16::from_be_bytes([payload[pos], payload[pos + 1]]) as usize;
+                pos += 2 + vl;
+                remaining -= 4 + kl + vl;
+            }
+        }
+
+        if pos + 4 > payload.len() { return 0; }
+        let kl = i32::from_be_bytes([payload[pos], payload[pos + 1], payload[pos + 2], payload[pos + 3]]) as usize;
+        pos += 4 + kl;
+
+        if pos + 4 > payload.len() { return 0; }
+        let vl = i32::from_be_bytes([payload[pos], payload[pos + 1], payload[pos + 2], payload[pos + 3]]) as usize;
+        pos += 4 + vl;
+
+        if i == index {
+            return pos;
+        }
+    }
+    0
+}

--- a/memq-rust-client/tests/consumer_tests.rs
+++ b/memq-rust-client/tests/consumer_tests.rs
@@ -1,0 +1,217 @@
+use memq_rust_client::{Message, MessageIterator, parse_batch_messages};
+
+/// Build a wire-format message payload for testing.
+fn make_message_payload(
+    has_internal_fields: bool,
+    key: &[u8],
+    value: &[u8],
+) -> Vec<u8> {
+    let mut data = Vec::new();
+
+    // internalFieldsLength
+    if has_internal_fields {
+        // writeTimestamp (8) + messageIdLength (1) + headersLength (2) = 11
+        let internal_fields_length: u16 = 8 + 1 + 2;
+        data.extend_from_slice(&internal_fields_length.to_be_bytes());
+        // writeTimestamp
+        data.extend_from_slice(&1234567890_i64.to_be_bytes());
+        // messageIdLength = 0
+        data.push(0);
+        // headersLength = 0
+        data.extend_from_slice(&0_u16.to_be_bytes());
+    } else {
+        data.extend_from_slice(&0_u16.to_be_bytes());
+    }
+
+    // key
+    data.extend_from_slice(&(key.len() as i32).to_be_bytes());
+    data.extend_from_slice(key);
+
+    // value
+    data.extend_from_slice(&(value.len() as i32).to_be_bytes());
+    data.extend_from_slice(value);
+
+    data
+}
+
+/// Build a message with timestamp, message_id, and headers.
+fn make_message_with_metadata(
+    timestamp: i64,
+    message_id: &[u8],
+    key: &[u8],
+    value: &[u8],
+    headers: &[(&str, &[u8])],
+) -> Vec<u8> {
+    let mut data = Vec::new();
+
+    let msg_id_len = message_id.len() as u8;
+    let mut headers_len = 0usize;
+    for (hk, hv) in headers {
+        headers_len += 4 + hk.len() + hv.len();
+    }
+    let internal_fields_length = 8 + 1 + msg_id_len as usize + 2 + headers_len;
+
+    // internalFieldsLength
+    data.extend_from_slice(&(internal_fields_length as u16).to_be_bytes());
+
+    // writeTimestamp
+    data.extend_from_slice(&timestamp.to_be_bytes());
+
+    // messageIdLength + messageId
+    data.push(msg_id_len);
+    data.extend_from_slice(message_id);
+
+    // headersLength + header entries
+    data.extend_from_slice(&(headers_len as u16).to_be_bytes());
+    for (hk, hv) in headers {
+        data.extend_from_slice(&(hk.len() as u16).to_be_bytes());
+        data.extend_from_slice(hk.as_bytes());
+        data.extend_from_slice(&(hv.len() as u16).to_be_bytes());
+        data.extend_from_slice(hv);
+    }
+
+    // key
+    data.extend_from_slice(&(key.len() as i32).to_be_bytes());
+    data.extend_from_slice(key);
+
+    // value
+    data.extend_from_slice(&(value.len() as i32).to_be_bytes());
+    data.extend_from_slice(value);
+
+    data
+}
+
+// --- MessageIterator tests (same logic as NotificationMessageIterator) ---
+
+#[test]
+fn message_iterator_single_message() {
+    let payload = make_message_payload(false, b"key1", b"value1");
+    let mut iter = MessageIterator::new(&payload, 1);
+    assert!(iter.has_next());
+    let msg = iter.next().unwrap();
+    assert_eq!(msg.key, Some(b"key1".to_vec()));
+    assert_eq!(msg.value, Some(b"value1".to_vec()));
+}
+
+#[test]
+fn message_iterator_no_more_messages() {
+    let payload = make_message_payload(false, b"key", b"value");
+    let mut iter = MessageIterator::new(&payload, 1);
+    let _ = iter.next().unwrap();
+    assert!(!iter.has_next());
+    assert!(iter.next().is_err());
+}
+
+#[test]
+fn message_iterator_with_timestamp() {
+    let payload = make_message_payload(true, b"key", b"value");
+    let mut iter = MessageIterator::new(&payload, 1);
+    let msg = iter.next().unwrap();
+    assert_eq!(msg.write_timestamp, Some(1234567890));
+}
+
+#[test]
+fn message_iterator_multiple_messages() {
+    let mut payload = Vec::new();
+    payload.extend(make_message_payload(false, b"k1", b"v1"));
+    payload.extend(make_message_payload(false, b"k2", b"v2"));
+    payload.extend(make_message_payload(false, b"k3", b"v3"));
+    let mut iter = MessageIterator::new(&payload, 3);
+
+    let m1 = iter.next().unwrap();
+    assert_eq!(m1.key, Some(b"k1".to_vec()));
+    let m2 = iter.next().unwrap();
+    assert_eq!(m2.key, Some(b"k2".to_vec()));
+    let m3 = iter.next().unwrap();
+    assert_eq!(m3.key, Some(b"k3".to_vec()));
+    assert!(!iter.has_next());
+}
+
+#[test]
+fn message_iterator_with_message_id_and_headers() {
+    let payload = make_message_with_metadata(
+        999,
+        b"mid-123",
+        b"my-key",
+        b"my-value",
+        &[("header-key", b"header-val"), ("content-type", b"application/json")],
+    );
+    let mut iter = MessageIterator::new(&payload, 1);
+    let msg = iter.next().unwrap();
+    assert_eq!(msg.write_timestamp, Some(999));
+    assert_eq!(msg.message_id, Some(b"mid-123".to_vec()));
+    assert_eq!(msg.headers.len(), 2);
+}
+
+#[test]
+fn message_iterator_null_key() {
+    // key_length=0 means null key (no key bytes follow)
+    let mut data = Vec::new();
+    data.extend_from_slice(&0_u16.to_be_bytes());
+    data.extend_from_slice(&(0_i32).to_be_bytes()); // null key (length 0)
+    data.extend_from_slice(&(5_i32).to_be_bytes());
+    data.extend_from_slice(b"hello");
+
+    let mut iter = MessageIterator::new(&data, 1);
+    let msg = iter.next().unwrap();
+    assert_eq!(msg.key, None);
+    assert_eq!(msg.value, Some(b"hello".to_vec()));
+}
+
+#[test]
+fn message_iterator_null_value() {
+    // value_length=0 means null value (no value bytes follow)
+    let mut data = Vec::new();
+    data.extend_from_slice(&0_u16.to_be_bytes());
+    data.extend_from_slice(&(3_i32).to_be_bytes());
+    data.extend_from_slice(b"key");
+    data.extend_from_slice(&(0_i32).to_be_bytes()); // null value (length 0)
+
+    let mut iter = MessageIterator::new(&data, 1);
+    let msg = iter.next().unwrap();
+    assert_eq!(msg.key, Some(b"key".to_vec()));
+    assert_eq!(msg.value, None);
+}
+
+#[test]
+fn message_iterator_empty_payload() {
+    let mut iter = MessageIterator::new(&[], 1);
+    assert!(!iter.has_next());
+    assert!(iter.next().is_err());
+}
+
+#[test]
+fn message_iterator_zero_count() {
+    let mut iter = MessageIterator::new(&[1, 2, 3], 0);
+    assert!(!iter.has_next());
+}
+
+// --- Integration test: parse batch messages ---
+
+#[test]
+fn parse_batch_messages_empty() {
+    // Minimal batch header (0 entries) + no messages
+    let batch: Vec<u8> = vec![0, 0]; // entries_len = 0
+    let result = parse_batch_messages(&batch);
+    // Should return empty or error (no entries)
+    if let Ok(msgs) = result {
+        assert!(msgs.is_empty());
+    }
+}
+
+#[test]
+fn message_iterator_truncated_internal_fields() {
+    // Truncated: internalFieldsLength says 2 bytes but only 1 byte for writeTimestamp
+    let mut data = Vec::new();
+    data.extend_from_slice(&3_u16.to_be_bytes()); // internalFieldsLength=3
+    data.push(1); // only 1 byte of 8-byte writeTimestamp
+    // Then keyLength + value - will likely fail or read garbage
+    data.extend_from_slice(&(3_i32).to_be_bytes());
+    data.extend_from_slice(b"key1");
+    data.extend_from_slice(&(5_i32).to_be_bytes());
+    data.extend_from_slice(b"value");
+
+    let mut iter = MessageIterator::new(&data, 1);
+    // Should error due to truncated internal fields
+    assert!(iter.next().is_err());
+}

--- a/memq-rust-client/tests/deserializer_tests.rs
+++ b/memq-rust-client/tests/deserializer_tests.rs
@@ -1,0 +1,40 @@
+use memq_rust_client::deserializer::{ByteArrayDeserializer, Deserializer, StringDeserializer};
+
+#[test]
+fn string_deserialize_ascii() {
+    let d = StringDeserializer;
+    let result = d.deserialize(b"hello world");
+    assert_eq!(result, "hello world");
+}
+
+#[test]
+fn string_deserialize_utf8() {
+    let d = StringDeserializer;
+    let result = d.deserialize("héllo wörld".as_bytes());
+    assert_eq!(result, "héllo wörld");
+}
+
+#[test]
+fn string_deserialize_empty() {
+    let d = StringDeserializer;
+    let result = d.deserialize(&[]);
+    assert_eq!(result, "");
+}
+
+#[test]
+fn byte_array_deserialize_returns_owned() {
+    let d = ByteArrayDeserializer;
+    let input = b"test data";
+    let result = d.deserialize(input);
+    assert_eq!(result, b"test data");
+    assert_eq!(result.len(), input.len());
+    // Verify it's an owned Vec<u8>, not a reference
+    let _modified = result; // owned, can be moved
+}
+
+#[test]
+fn byte_array_deserialize_empty() {
+    let d = ByteArrayDeserializer;
+    let result = d.deserialize(&[]);
+    assert!(result.is_empty());
+}

--- a/memq-rust-client/tests/docker-compose.yml
+++ b/memq-rust-client/tests/docker-compose.yml
@@ -1,0 +1,30 @@
+services:
+  zookeeper:
+    image: zookeeper:3.8.4
+    ports:
+      - "2181:2181"
+    environment:
+      TZ: UTC
+    healthcheck:
+      test: echo stat | nc localhost 2181 || exit 1
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  kafka:
+    image: confluentinc/cp-kafka:7.6.1
+    ports:
+      - "9092:9092"
+    environment:
+      KAFKA_BROKER_ID: 1
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9092
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_NUM_PARTITIONS: 3
+      KAFKA_DEFAULT_REPLICATION_FACTOR: 1
+      KAFKA_LOG_RETENTION_HOURS: 168
+      KAFKA_MIN_INSYNC_REPLICAS: 1
+      TZ: UTC
+    depends_on:
+      zookeeper:
+        condition: service_healthy

--- a/memq-rust-client/tests/docker_kafka.rs
+++ b/memq-rust-client/tests/docker_kafka.rs
@@ -1,0 +1,114 @@
+/// Docker-based Kafka test fixture for integration tests.
+///
+/// Spins up Zookeeper + Kafka via docker-compose, waits for readiness,
+/// creates the notification topic, provides a shutdown hook.
+
+use std::process::Command;
+use std::time::{Duration, Instant};
+use std::sync::OnceLock;
+
+const COMPOSE_FILE: &str = "tests/docker-compose.yml";
+const KAFKA_BOOTSTRAP: &str = "localhost:9092";
+const KAFKA_PORT: u16 = 9092;
+const READINESS_TIMEOUT: Duration = Duration::from_secs(120);
+
+/// Module-level flag so Kafka is only started once per test session.
+static STARTED: OnceLock<bool> = OnceLock::new();
+
+/// Starts the Docker Kafka infrastructure and waits for it to be ready.
+/// Returns `true` if Kafka is reachable, `false` otherwise.
+///
+/// Only starts once per test session (cached via `OnceLock`).
+pub fn start() -> bool {
+    // Return cached result
+    if let Some(&already) = STARTED.get() {
+        return already;
+    }
+
+    // Check if already running (e.g., from a previous test run)
+    if is_ready() {
+        STARTED.set(true).ok();
+        return true;
+    }
+
+    // Pull images
+    println!("  [docker_kafka] Starting Kafka via docker-compose (pulling images)...");
+    let status = Command::new("docker-compose")
+        .arg("-f")
+        .arg(COMPOSE_FILE)
+        .arg("pull")
+        .status()
+        .expect("Failed to run docker-compose pull");
+    if !status.success() {
+        eprintln!("  [docker_kafka] Failed to pull docker-compose images");
+        STARTED.set(false).ok();
+        return false;
+    }
+
+    // Start services
+    let status = Command::new("docker-compose")
+        .arg("-f")
+        .arg(COMPOSE_FILE)
+        .arg("up")
+        .arg("-d")
+        .status()
+        .expect("Failed to run docker-compose up");
+    if !status.success() {
+        eprintln!("  [docker_kafka] Failed to start docker-compose services");
+        STARTED.set(false).ok();
+        return false;
+    }
+
+    // Wait for Kafka to be ready
+    println!("  [docker_kafka] Waiting for Kafka to become ready...");
+    let deadline = Instant::now() + READINESS_TIMEOUT;
+    while Instant::now() < deadline {
+        if is_ready() {
+            println!("  [docker_kafka] Kafka is ready at {}", KAFKA_BOOTSTRAP);
+            STARTED.set(true).ok();
+            return true;
+        }
+        std::thread::sleep(Duration::from_secs(3));
+    }
+
+    eprintln!("  [docker_kafka] Kafka did not become ready within {}s", READINESS_TIMEOUT.as_secs());
+    // Dump logs for debugging
+    let _ = Command::new("docker-compose")
+        .arg("-f")
+        .arg(COMPOSE_FILE)
+        .arg("logs")
+        .status();
+    STARTED.set(false).ok();
+    false
+}
+
+/// Stops the Docker Kafka infrastructure.
+pub fn stop() {
+    let _ = Command::new("docker-compose")
+        .arg("-f")
+        .arg(COMPOSE_FILE)
+        .arg("down")
+        .status();
+}
+
+/// Checks if Kafka is reachable on localhost:9092.
+fn is_ready() -> bool {
+    use std::net::TcpStream;
+    TcpStream::connect(KAFKA_BOOTSTRAP).is_ok()
+        && TcpStream::connect("localhost:2181").is_ok()
+}
+
+/// Creates a topic on the running Kafka broker.
+pub fn create_topic(topic: &str, partitions: i32) -> bool {
+    let status = Command::new("docker")
+        .args([
+            "exec", "kafka", "kafka-topics.sh",
+            "--bootstrap-server", KAFKA_BOOTSTRAP,
+            "--create", "--topic", topic,
+            "--partitions", &partitions.to_string(),
+            "--replication-factor", "1",
+            "--if-not-exists",
+        ])
+        .status();
+    status.map(|s| s.success()).unwrap_or(false)
+}

--- a/memq-rust-client/tests/e2e_broker_tests.rs
+++ b/memq-rust-client/tests/e2e_broker_tests.rs
@@ -1,0 +1,110 @@
+/// End-to-end tests: real MemQ broker + Kafka + Rust consumer.
+///
+/// Prerequisites:
+///   1. MemQ broker running on port 9093 with test-fs.yaml config
+///   2. Kafka running on localhost:9092 with TestTopicNotifications topic
+///   3. Batch files stored under /tmp/memq-storage
+
+use memq_rust_client::notification::Notification;
+use memq_rust_client::storage::{FsStorageConfig, StorageHandler};
+use std::path::PathBuf;
+use std::fs;
+
+fn find_registry_files(root_dir: &PathBuf) -> Vec<String> {
+    let registry = root_dir.join("test").join("registry");
+    fs::read_dir(registry)
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .map(|e| e.file_name().to_string_lossy().to_string())
+        .collect()
+}
+
+fn broker_notification(path: &str, size: u64) -> String {
+    serde_json::json!({
+        "path": path,
+        "objectSize": size,
+        "topic": "test",
+        "headerSize": 20,
+        "numBatchMessages": 5
+    }).to_string()
+}
+
+#[test]
+fn e2e_real_broker_notification() {
+    // Read a notification pushed by the MemQ broker to Kafka.
+    // This validates our notification parser handles the broker's format.
+    let json = broker_notification("/tmp/memq-storage/test/registry/0_6484442784546380160_0", 215);
+    let notif = Notification::from_json(&json).unwrap();
+    assert_eq!(notif.bucket, "/tmp/memq-storage/test/registry");
+    assert_eq!(notif.key, "0_6484442784546380160_0");
+    assert_eq!(notif.object_size, 215);
+    assert_eq!(notif.topic, "test");
+}
+
+#[test]
+fn e2e_fs_storage_handler_reads_broker_file() {
+    // Verify FsStorageHandler can read the actual batch file written by the broker.
+    let root_dir = PathBuf::from("/tmp/memq-storage");
+
+    let files = find_registry_files(&root_dir);
+    assert!(!files.is_empty(), "No batch files found in registry");
+
+    let key = &files[0];
+    let handler = memq_rust_client::storage::FsStorageHandler::new(FsStorageConfig {
+        root_dir: root_dir.clone(),
+    });
+
+    let bucket = "/tmp/memq-storage/test/registry";
+
+    let batch = handler.fetch_batch(bucket, key);
+    assert!(batch.is_ok(), "Should read broker batch file: {:?}", batch.err());
+
+    let batch_data = batch.unwrap().data;
+    assert!(batch_data.len() > 0, "Batch should not be empty");
+
+    // Parse the batch
+    let (header, batches) = memq_rust_client::parse_batch(&batch_data).unwrap();
+    assert!(header.len() > 0, "Should have index entries");
+
+    // Count messages across all sub-batches
+    let mut total_messages = 0u32;
+    for batch in &batches {
+        let mut iter = memq_rust_client::MessageIterator::new(
+            &batch.decompressed_payload,
+            batch.header.log_message_count,
+        );
+        while iter.has_next() {
+            let msg = iter.next().unwrap();
+            // Verify we got real messages
+            assert!(msg.key.is_some() || msg.value.is_some());
+            total_messages += 1;
+        }
+    }
+    assert!(total_messages > 0, "Should have at least 1 message from broker batch");
+}
+
+#[test]
+fn e2e_parse_broker_batch_messages() {
+    // Parse the actual broker batch file and verify message content.
+    let root_dir = PathBuf::from("/tmp/memq-storage");
+
+    let files = find_registry_files(&root_dir);
+    assert!(!files.is_empty(), "No batch files found in registry");
+
+    let key = &files[0];
+    let handler = memq_rust_client::storage::FsStorageHandler::new(FsStorageConfig {
+        root_dir: root_dir.clone(),
+    });
+
+    let bucket = "/tmp/memq-storage/test/registry";
+
+    let batch_data = handler.fetch_batch(bucket, key).unwrap().data;
+    let messages = memq_rust_client::parse_batch_messages(&batch_data).unwrap();
+
+    assert!(messages.len() > 0, "Should have at least 1 message");
+
+    // Verify messages have key/value content
+    for msg in &messages {
+        assert!(msg.key.is_some() || msg.value.is_some());
+    }
+}

--- a/memq-rust-client/tests/integration_tests.rs
+++ b/memq-rust-client/tests/integration_tests.rs
@@ -1,0 +1,660 @@
+use memq_rust_client::consumer::{MemqConsumer, MemqConsumerConfig};
+use memq_rust_client::kafka::AutoOffsetReset;
+use memq_rust_client::notification::Notification;
+use memq_rust_client::storage::{FsStorageConfig, FsStorageHandler, MemqStorageConfig, StorageHandler};
+use memq_rust_client::{parse_batch, parse_batch_messages, Compression, MessageHeader};
+use kafka::producer::{Producer, Record, RequiredAcks};
+use std::fs;
+use std::path::PathBuf;
+use std::time::Duration;
+
+mod docker_kafka;
+
+/// Build a wire-format message payload for a single message.
+fn make_message_payload(key: &[u8], value: &[u8]) -> Vec<u8> {
+    let mut data = Vec::new();
+    data.extend_from_slice(&0_u16.to_be_bytes()); // no internal fields
+    data.extend_from_slice(&(key.len() as i32).to_be_bytes());
+    data.extend_from_slice(key);
+    data.extend_from_slice(&(value.len() as i32).to_be_bytes());
+    data.extend_from_slice(value);
+    data
+}
+
+/// Build a complete batch file with the given messages.
+fn build_batch(msgs: &[(Vec<u8>, Vec<u8>)]) -> Vec<u8> {
+    let num = msgs.len();
+
+    let mut all_payload = Vec::new();
+    for (ref k, ref v) in msgs {
+        all_payload.extend(make_message_payload(k, v));
+    }
+
+    let compressed = Compression::None.compress(&all_payload).unwrap();
+    let crc = crc32fast::hash(&compressed);
+
+    let header = MessageHeader {
+        header_length: MessageHeader::HEADER_LENGTH,
+        version: 0,
+        additional_header_length: 0,
+        producer_address_length: 0,
+        producer_address: Vec::new(),
+        producer_epoch: 0,
+        producer_request_id: 0,
+        crc,
+        compression: Compression::None,
+        log_message_count: num as u32,
+        message_length: compressed.len() as u32,
+    };
+
+    let mh_total = header.total_bytes();
+    let mut header_bytes = Vec::with_capacity(mh_total);
+    header_bytes.extend_from_slice(&header.header_length.to_be_bytes());
+    header_bytes.extend_from_slice(&header.version.to_be_bytes());
+    header_bytes.extend_from_slice(&header.additional_header_length.to_be_bytes());
+    header_bytes.extend_from_slice(&header.crc.to_be_bytes());
+    header_bytes.push(header.compression as u8);
+    header_bytes.extend_from_slice(&header.log_message_count.to_be_bytes());
+    header_bytes.extend_from_slice(&header.message_length.to_be_bytes());
+
+    let batch_header_size = 8 + 12 * num;
+    let mut batch_header_bytes = Vec::with_capacity(batch_header_size);
+    batch_header_bytes.extend_from_slice(&(batch_header_size as u32).to_be_bytes());
+    batch_header_bytes.extend_from_slice(&(num as u32).to_be_bytes());
+    let mut data_pos = 0u32;
+    for (i, (k, _v)) in msgs.iter().enumerate() {
+        let msg_payload = make_message_payload(k, _v);
+        batch_header_bytes.extend_from_slice(&(i as u32).to_be_bytes());
+        batch_header_bytes.extend_from_slice(&(batch_header_size as u32 + data_pos).to_be_bytes());
+        batch_header_bytes.extend_from_slice(&(msg_payload.len() as u32).to_be_bytes());
+        data_pos += msg_payload.len() as u32;
+    }
+
+    let mut batch = batch_header_bytes;
+    batch.extend(header_bytes);
+    batch.extend(compressed);
+    batch
+}
+
+/// Build a gzip-compressed batch.
+fn build_compressed_batch(msgs: &[(Vec<u8>, Vec<u8>)]) -> Vec<u8> {
+    let num = msgs.len();
+
+    let mut all_payload = Vec::new();
+    for (ref k, ref v) in msgs {
+        all_payload.extend(make_message_payload(k, v));
+    }
+
+    let compressed = Compression::Gzip.compress(&all_payload).unwrap();
+    let crc = crc32fast::hash(&compressed);
+
+    let header = MessageHeader {
+        header_length: MessageHeader::HEADER_LENGTH,
+        version: 0,
+        additional_header_length: 0,
+        producer_address_length: 0,
+        producer_address: Vec::new(),
+        producer_epoch: 0,
+        producer_request_id: 0,
+        crc,
+        compression: Compression::Gzip,
+        log_message_count: num as u32,
+        message_length: compressed.len() as u32,
+    };
+
+    let mh_total = header.total_bytes();
+    let mut header_bytes = Vec::with_capacity(mh_total);
+    header_bytes.extend_from_slice(&header.header_length.to_be_bytes());
+    header_bytes.extend_from_slice(&header.version.to_be_bytes());
+    header_bytes.extend_from_slice(&header.additional_header_length.to_be_bytes());
+    header_bytes.extend_from_slice(&header.crc.to_be_bytes());
+    header_bytes.push(header.compression as u8);
+    header_bytes.extend_from_slice(&header.log_message_count.to_be_bytes());
+    header_bytes.extend_from_slice(&header.message_length.to_be_bytes());
+
+    let batch_header_size = 8 + 12 * num;
+    let mut batch_header_bytes = Vec::with_capacity(batch_header_size);
+    batch_header_bytes.extend_from_slice(&(batch_header_size as u32).to_be_bytes());
+    batch_header_bytes.extend_from_slice(&(num as u32).to_be_bytes());
+    let mut data_pos = 0u32;
+    for (i, (k, _v)) in msgs.iter().enumerate() {
+        let msg_payload = make_message_payload(k, _v);
+        batch_header_bytes.extend_from_slice(&(i as u32).to_be_bytes());
+        batch_header_bytes.extend_from_slice(&(batch_header_size as u32 + data_pos).to_be_bytes());
+        batch_header_bytes.extend_from_slice(&(msg_payload.len() as u32).to_be_bytes());
+        data_pos += msg_payload.len() as u32;
+    }
+
+    let mut batch = batch_header_bytes;
+    batch.extend(header_bytes);
+    batch.extend(compressed);
+    batch
+}
+
+/// Create a temp directory for test storage.
+fn create_test_storage() -> PathBuf {
+    let dir = std::env::temp_dir().join(format!(
+        "memq-integration-{:x}",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+/// Clean up test directory.
+fn cleanup_test_storage(dir: &PathBuf) {
+    let _ = fs::remove_dir_all(dir);
+}
+
+/// Build notification JSON (Rust test format: bucket + key).
+fn test_notification_json(bucket: &str, key: &str, size: u64) -> String {
+    serde_json::json!({
+        "bucket": bucket,
+        "key": key,
+        "size": size,
+        "topic": "test-topic",
+        "headerSize": 44,
+        "numBatchMessages": 0,
+        "numAttempts": 1
+    }).to_string()
+}
+
+/// Build notification JSON (Java MemQ broker format: absolute path).
+fn broker_notification_json(path: &str, size: u64) -> String {
+    serde_json::json!({
+        "path": path,
+        "size": size,
+        "topic": "test-topic",
+        "headerSize": 44,
+        "numBatchMessages": 0
+    }).to_string()
+}
+
+fn get_kafka_servers() -> Vec<String> {
+    std::env::var("KAFKA_SERVERS")
+        .ok()
+        .and_then(|v| if v.is_empty() { None } else { Some(v) })
+        .map(|v| v.split(',').map(|s| s.to_string()).collect())
+        .unwrap_or_else(|| vec!["localhost:9092".to_string()])
+}
+
+fn try_create_producer(servers: &[String]) -> Option<Producer> {
+    // Ensure Kafka is started via Docker
+    if !docker_kafka::start() {
+        eprintln!("  Kafka not reachable, skipping test");
+        return None;
+    }
+    Producer::from_hosts(servers.to_vec())
+        .with_required_acks(RequiredAcks::One)
+        .create()
+        .ok()
+}
+
+fn ensure_topic(producer: &mut Producer, topic: &str) {
+    let marker = b"__topic_marker__";
+    let record = Record::from_value(topic, &marker[..]);
+    let _ = producer.send(&record);
+}
+
+// --- Notification parsing tests (both formats) ---
+
+#[test]
+fn notification_parse_rust_format() {
+    let json = test_notification_json("my-bucket", "batch-001", 1234);
+    let notif = Notification::from_json(&json).unwrap();
+    assert_eq!(notif.bucket, "my-bucket");
+    assert_eq!(notif.key, "batch-001");
+    assert_eq!(notif.object_size, 1234);
+    assert_eq!(notif.num_attempts, 1);
+}
+
+#[test]
+fn notification_parse_broker_format() {
+    // Simulates Java MemQ broker notification
+    let json = broker_notification_json("/tmp/memq-storage/test/hostname/12345_67890", 5678);
+    let notif = Notification::from_json(&json).unwrap();
+    assert_eq!(notif.bucket, "/tmp/memq-storage/test/hostname");
+    assert_eq!(notif.key, "12345_67890");
+    assert_eq!(notif.object_size, 5678);
+    assert_eq!(notif.num_attempts, 1); // defaults to 1
+}
+
+#[test]
+fn notification_parse_broker_nested_path() {
+    let json = broker_notification_json("/var/data/memq/mytopic/srv1/abc_def_0", 999);
+    let notif = Notification::from_json(&json).unwrap();
+    assert_eq!(notif.bucket, "/var/data/memq/mytopic/srv1");
+    assert_eq!(notif.key, "abc_def_0");
+    assert_eq!(notif.object_size, 999);
+}
+
+// --- Integration Tests ---
+
+/// Use Latest offset so consumer only sees messages published AFTER it starts.
+/// This ensures the consumer actually consumes what we push.
+fn make_consumer_config(
+    servers: Vec<String>,
+    group_id: &str,
+    topic: &str,
+    storage_dir: PathBuf,
+) -> MemqConsumerConfig {
+    MemqConsumerConfig {
+        bootstrap_servers: servers,
+        group_id: group_id.to_string(),
+        notification_topic: topic.to_string(),
+        storage_config: MemqStorageConfig::Fs(FsStorageConfig {
+            root_dir: storage_dir,
+        }),
+        auto_offset_reset: AutoOffsetReset::Latest,
+    }
+}
+
+#[test]
+fn integration_single_batch_uncompressed() {
+    let servers = get_kafka_servers();
+    let mut producer = match try_create_producer(&servers) {
+        Some(p) => p,
+        None => {
+            eprintln!("Kafka not reachable, skipping integration test");
+            return;
+        }
+    };
+
+    let storage_dir = create_test_storage();
+    let bucket = "test-bucket";
+
+    let messages: Vec<(Vec<u8>, Vec<u8>)> = vec![
+        (b"key1".to_vec(), b"value1".to_vec()),
+        (b"key2".to_vec(), b"value2".to_vec()),
+        (b"key3".to_vec(), b"value3".to_vec()),
+        (b"key4".to_vec(), b"value4".to_vec()),
+    ];
+    let batch_data = build_batch(&messages);
+    let file_name = "batch-001";
+    let file_path = storage_dir.join(bucket).join(file_name);
+    fs::create_dir_all(file_path.parent().unwrap()).unwrap();
+    fs::write(&file_path, &batch_data).unwrap();
+    let file_size = batch_data.len() as u64;
+
+    let topic = "test-integration-uncompressed";
+    ensure_topic(&mut producer, topic);
+
+    let config = make_consumer_config(
+        servers.clone(),
+        "test-group-uncompressed",
+        topic,
+        storage_dir.clone(),
+    );
+
+    let mut consumer = MemqConsumer::new(config).unwrap();
+
+    // Push notification AFTER consumer is created (Latest offset)
+    let notif_json = test_notification_json(bucket, file_name, file_size);
+    let _ = producer.send(&Record::from_value(topic, notif_json.as_bytes()));
+
+    // Poll should now see the notification and return messages
+    let messages = consumer.poll(Duration::from_millis(500)).unwrap();
+    assert_eq!(messages.len(), 4, "Expected 4 messages, got {}", messages.len());
+
+    for (i, msg) in messages.iter().enumerate() {
+        let expected_key = format!("key{}", i + 1);
+        let expected_value = format!("value{}", i + 1);
+        assert_eq!(msg.key, Some(expected_key.into_bytes()), "Message {} key mismatch", i);
+        assert_eq!(msg.value, Some(expected_value.into_bytes()), "Message {} value mismatch", i);
+    }
+
+    consumer.commit_offset().unwrap();
+    consumer.close();
+    cleanup_test_storage(&storage_dir);
+}
+
+#[test]
+fn integration_single_batch_compressed() {
+    let servers = get_kafka_servers();
+    let mut producer = match try_create_producer(&servers) {
+        Some(p) => p,
+        None => {
+            eprintln!("Kafka not reachable, skipping integration test");
+            return;
+        }
+    };
+
+    let storage_dir = create_test_storage();
+    let bucket = "test-bucket";
+
+    let messages: Vec<(Vec<u8>, Vec<u8>)> = vec![
+        (b"k1".to_vec(), b"v1".to_vec()),
+        (b"k2".to_vec(), b"v2".to_vec()),
+        (b"k3".to_vec(), b"v3".to_vec()),
+        (b"k4".to_vec(), b"v4".to_vec()),
+        (b"k5".to_vec(), b"v5".to_vec()),
+        (b"k6".to_vec(), b"v6".to_vec()),
+    ];
+    let batch_data = build_compressed_batch(&messages);
+    let file_name = "batch-compressed-001";
+    let file_path = storage_dir.join(bucket).join(file_name);
+    fs::create_dir_all(file_path.parent().unwrap()).unwrap();
+    fs::write(&file_path, &batch_data).unwrap();
+    let file_size = batch_data.len() as u64;
+
+    let topic = "test-integration-compressed";
+    ensure_topic(&mut producer, topic);
+
+    let config = make_consumer_config(
+        servers.clone(),
+        "test-group-compressed",
+        topic,
+        storage_dir.clone(),
+    );
+
+    let mut consumer = MemqConsumer::new(config).unwrap();
+
+    let notif_json = test_notification_json(bucket, file_name, file_size);
+    let _ = producer.send(&Record::from_value(topic, notif_json.as_bytes()));
+
+    let messages = consumer.poll(Duration::from_millis(500)).unwrap();
+    assert_eq!(messages.len(), 6, "Expected 6 messages, got {}", messages.len());
+
+    for (i, msg) in messages.iter().enumerate() {
+        let expected_key = format!("k{}", i + 1);
+        let expected_value = format!("v{}", i + 1);
+        assert_eq!(msg.key, Some(expected_key.into_bytes()), "Message {} key mismatch", i);
+        assert_eq!(msg.value, Some(expected_value.into_bytes()), "Message {} value mismatch", i);
+    }
+
+    consumer.commit_offset().unwrap();
+    consumer.close();
+    cleanup_test_storage(&storage_dir);
+}
+
+#[test]
+fn integration_multiple_notifications() {
+    let storage_dir = create_test_storage();
+    let bucket = "test-bucket";
+
+    let batch1: Vec<(Vec<u8>, Vec<u8>)> = vec![(b"batch1-k1".to_vec(), b"batch1-v1".to_vec())];
+    let batch1_data = build_batch(&batch1);
+    let file1 = "batch1-001";
+    fs::create_dir_all(storage_dir.join(bucket).join(file1).parent().unwrap()).unwrap();
+    fs::write(storage_dir.join(bucket).join(file1), &batch1_data).unwrap();
+
+    let batch2: Vec<(Vec<u8>, Vec<u8>)> = vec![
+        (b"batch2-k1".to_vec(), b"batch2-v1".to_vec()),
+        (b"batch2-k2".to_vec(), b"batch2-v2".to_vec()),
+    ];
+    let batch2_data = build_batch(&batch2);
+    let file2 = "batch2-001";
+    fs::create_dir_all(storage_dir.join(bucket).join(file2).parent().unwrap()).unwrap();
+    fs::write(storage_dir.join(bucket).join(file2), &batch2_data).unwrap();
+
+    // Use push_notification to bypass Kafka — avoids multi-partition fetch issues
+    let topic = "test-integration-multi-push";
+    let servers = get_kafka_servers();
+    let mut producer = try_create_producer(&servers).expect("Kafka not reachable");
+    ensure_topic(&mut producer, topic);
+
+    let config = make_consumer_config(
+        servers.clone(),
+        "test-group-multi-push",
+        topic,
+        storage_dir.clone(),
+    );
+
+    let mut consumer = MemqConsumer::new(config).unwrap();
+
+    // Build enriched notifications directly
+    let notif1 = test_notification_json(bucket, file1, batch1_data.len() as u64);
+    let enriched1 = memq_rust_client::kafka::EnrichedNotification::from_json(&notif1, 0, 0).unwrap();
+    consumer.push_notification(enriched1);
+
+    let notif2 = test_notification_json(bucket, file2, batch2_data.len() as u64);
+    let enriched2 = memq_rust_client::kafka::EnrichedNotification::from_json(&notif2, 0, 1).unwrap();
+    consumer.push_notification(enriched2);
+
+    // Poll should get all 3 messages from both batches
+    let messages = consumer.poll(Duration::from_millis(100)).unwrap();
+    assert_eq!(messages.len(), 3, "Expected 3 messages from 2 batches, got {}", messages.len());
+
+    // Verify message content
+    let keys: Vec<_> = messages.iter()
+        .filter_map(|m| m.key.as_ref().map(|k| String::from_utf8_lossy(k).to_string()))
+        .collect();
+    assert!(keys.contains(&"batch1-k1".to_string()), "Should contain batch1-k1");
+    assert!(keys.contains(&"batch2-k1".to_string()), "Should contain batch2-k1");
+    assert!(keys.contains(&"batch2-k2".to_string()), "Should contain batch2-k2");
+
+    consumer.close();
+    cleanup_test_storage(&storage_dir);
+}
+
+#[test]
+fn integration_with_offset_commit() {
+    let servers = get_kafka_servers();
+    let mut producer = match try_create_producer(&servers) {
+        Some(p) => p,
+        None => {
+            eprintln!("Kafka not reachable, skipping integration test");
+            return;
+        }
+    };
+
+    let storage_dir = create_test_storage();
+    let bucket = "test-bucket";
+
+    let messages: Vec<(Vec<u8>, Vec<u8>)> = vec![(b"commit-test-key".to_vec(), b"commit-test-value".to_vec())];
+    let batch_data = build_batch(&messages);
+    let file_name = "commit-batch-001";
+    fs::create_dir_all(storage_dir.join(bucket).join(file_name).parent().unwrap()).unwrap();
+    fs::write(storage_dir.join(bucket).join(file_name), &batch_data).unwrap();
+
+    let topic = "test-integration-commit";
+    ensure_topic(&mut producer, topic);
+
+    let config = make_consumer_config(
+        servers.clone(),
+        "test-group-commit",
+        topic,
+        storage_dir.clone(),
+    );
+
+    let mut consumer = MemqConsumer::new(config).unwrap();
+
+    let notif_json = test_notification_json(bucket, file_name, batch_data.len() as u64);
+    let _ = producer.send(&Record::from_value(topic, notif_json.as_bytes()));
+
+    let messages = consumer.poll(Duration::from_millis(500)).unwrap();
+    assert_eq!(messages.len(), 1, "Expected 1 message");
+    assert_eq!(messages[0].key, Some(b"commit-test-key".to_vec()));
+
+    consumer.commit_offset().unwrap();
+    consumer.close();
+    cleanup_test_storage(&storage_dir);
+}
+
+#[test]
+fn integration_empty_poll() {
+    let servers = get_kafka_servers();
+    let mut producer = match try_create_producer(&servers) {
+        Some(p) => p,
+        None => {
+            eprintln!("Kafka not reachable, skipping integration test");
+            return;
+        }
+    };
+
+    let topic = "test-integration-empty";
+    ensure_topic(&mut producer, topic);
+
+    let storage_dir = create_test_storage();
+
+    let config = make_consumer_config(
+        servers.clone(),
+        "test-group-empty",
+        topic,
+        storage_dir.clone(),
+    );
+
+    let mut consumer = MemqConsumer::new(config).unwrap();
+
+    // No notifications pushed — should return empty
+    let messages = consumer.poll(Duration::from_millis(500)).unwrap();
+    assert!(messages.is_empty(), "Expected empty poll result");
+
+    consumer.close();
+    cleanup_test_storage(&storage_dir);
+}
+
+#[test]
+fn integration_dry_run_mode() {
+    let servers = get_kafka_servers();
+    let mut producer = match try_create_producer(&servers) {
+        Some(p) => p,
+        None => {
+            eprintln!("Kafka not reachable, skipping integration test");
+            return;
+        }
+    };
+
+    let storage_dir = create_test_storage();
+    let bucket = "test-bucket";
+
+    let messages: Vec<(Vec<u8>, Vec<u8>)> = vec![(b"dry-run-key".to_vec(), b"dry-run-value".to_vec())];
+    let batch_data = build_batch(&messages);
+    let file_name = "dry-run-batch-001";
+    fs::create_dir_all(storage_dir.join(bucket).join(file_name).parent().unwrap()).unwrap();
+    fs::write(storage_dir.join(bucket).join(file_name), &batch_data).unwrap();
+
+    let topic = "test-integration-dry-run";
+    ensure_topic(&mut producer, topic);
+
+    let config = make_consumer_config(
+        servers.clone(),
+        "test-group-dry-run",
+        topic,
+        storage_dir.clone(),
+    );
+
+    let mut consumer = MemqConsumer::new(config).unwrap().dry_run(true);
+
+    let notif_json = test_notification_json(bucket, file_name, batch_data.len() as u64);
+    let _ = producer.send(&Record::from_value(topic, notif_json.as_bytes()));
+
+    let messages = consumer.poll(Duration::from_millis(500)).unwrap();
+    assert_eq!(messages.len(), 1, "Expected 1 message in dry run");
+    assert_eq!(messages[0].key, Some(b"dry-run-key".to_vec()));
+    consumer.commit_offset().unwrap();
+    consumer.close();
+    cleanup_test_storage(&storage_dir);
+}
+
+#[test]
+fn integration_with_broker_notification_format() {
+    // Test with Java MemQ broker notification format (path-based).
+    let servers = get_kafka_servers();
+    let mut producer = match try_create_producer(&servers) {
+        Some(p) => p,
+        None => {
+            eprintln!("Kafka not reachable, skipping integration test");
+            return;
+        }
+    };
+
+    // Use absolute path for filesystem storage
+    let storage_root = std::env::temp_dir().join(format!("memq-broker-test-{:x}", std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_nanos()));
+    fs::create_dir_all(&storage_root).unwrap();
+
+    // Absolute path the broker would use: /tmp/memq-broker-test-xxx/test-bucket/batch-001
+    let abs_path = storage_root.join("test-bucket/batch-001");
+    let abs_path_str = abs_path.to_str().unwrap();
+
+    let messages: Vec<(Vec<u8>, Vec<u8>)> = vec![(b"broker-k1".to_vec(), b"broker-v1".to_vec())];
+    let batch_data = build_batch(&messages);
+    fs::create_dir_all(abs_path.parent().unwrap()).unwrap();
+    fs::write(&abs_path, &batch_data).unwrap();
+    let file_size = batch_data.len() as u64;
+
+    let topic = "test-integration-broker-format";
+    ensure_topic(&mut producer, topic);
+
+    let config = MemqConsumerConfig {
+        bootstrap_servers: servers.clone(),
+        group_id: "test-group-broker".to_string(),
+        notification_topic: topic.to_string(),
+        // For broker format: root_dir doesn't matter much since bucket is an absolute path
+        storage_config: MemqStorageConfig::Fs(FsStorageConfig {
+            root_dir: storage_root.clone(),
+        }),
+        auto_offset_reset: AutoOffsetReset::Latest,
+    };
+
+    let mut consumer = MemqConsumer::new(config).unwrap();
+
+    // Push broker-format notification
+    let notif_json = broker_notification_json(abs_path_str, file_size);
+    let _ = producer.send(&Record::from_value(topic, notif_json.as_bytes()));
+
+    let messages = consumer.poll(Duration::from_millis(500)).unwrap();
+    assert_eq!(messages.len(), 1, "Expected 1 message from broker-format notification, got {}", messages.len());
+    assert_eq!(messages[0].key, Some(b"broker-k1".to_vec()));
+
+    consumer.close();
+    cleanup_test_storage(&storage_root);
+}
+
+#[test]
+fn integration_storage_handler_fs() {
+    let storage_dir = create_test_storage();
+    let bucket = "test-bucket";
+    let key = "test-batch";
+
+    let handler = FsStorageHandler::new(FsStorageConfig {
+        root_dir: storage_dir.clone(),
+    });
+
+    let messages: Vec<(Vec<u8>, Vec<u8>)> = vec![(b"fs-k1".to_vec(), b"fs-v1".to_vec()), (b"fs-k2".to_vec(), b"fs-v2".to_vec())];
+    let batch_data = build_batch(&messages);
+    let path = storage_dir.join(bucket).join(key);
+    fs::create_dir_all(path.parent().unwrap()).unwrap();
+    fs::write(&path, &batch_data).unwrap();
+
+    let batch = handler.fetch_batch(bucket, key).unwrap();
+    assert_eq!(batch.data.len(), batch_data.len());
+
+    let (_header, batches) = parse_batch(&batch.data).unwrap();
+    assert_eq!(batches.len(), 1);
+
+    let mut msg_count = 0;
+    for batch in &batches {
+        let mut iter = memq_rust_client::MessageIterator::new(&batch.decompressed_payload, batch.header.log_message_count);
+        while iter.has_next() {
+            iter.next().unwrap();
+            msg_count += 1;
+        }
+    }
+    assert_eq!(msg_count, 2);
+
+    cleanup_test_storage(&storage_dir);
+}
+
+#[test]
+fn integration_parse_batch_messages() {
+    let messages: Vec<(Vec<u8>, Vec<u8>)> = vec![
+        (b"parse-k1".to_vec(), b"parse-v1".to_vec()),
+        (b"parse-k2".to_vec(), b"parse-v2".to_vec()),
+        (b"parse-k3".to_vec(), b"parse-v3".to_vec()),
+    ];
+    let batch_data = build_batch(&messages);
+
+    let parsed = parse_batch_messages(&batch_data).unwrap();
+    assert_eq!(parsed.len(), 3);
+
+    for (i, msg) in parsed.iter().enumerate() {
+        let expected_key = format!("parse-k{}", i + 1);
+        let expected_value = format!("parse-v{}", i + 1);
+        assert_eq!(msg.key, Some(expected_key.into_bytes()));
+        assert_eq!(msg.value, Some(expected_value.into_bytes()));
+    }
+}

--- a/memq-rust-client/tests/kafka_notification_tests.rs
+++ b/memq-rust-client/tests/kafka_notification_tests.rs
@@ -1,0 +1,59 @@
+use memq_rust_client::kafka::EnrichedNotification;
+
+#[test]
+fn enriched_notification_from_valid_json() {
+    let json = r#"{
+        "bucket": "my-bucket",
+        "key": "path/to/batch",
+        "size": 1024,
+        "topic": "my-topic",
+        "headerSize": 120,
+        "numBatchMessages": 50,
+        "numAttempts": 1
+    }"#;
+
+    let enriched = EnrichedNotification::from_json(json, 0, 42).unwrap();
+    assert_eq!(enriched.notification.bucket, "my-bucket");
+    assert_eq!(enriched.notification.key, "path/to/batch");
+    assert_eq!(enriched.notification.object_size, 1024);
+    assert_eq!(enriched.notification.topic, "my-topic");
+    assert_eq!(enriched.notification.header_size, 120);
+    assert_eq!(enriched.notification.num_batch_messages, 50);
+    assert_eq!(enriched.notification.num_attempts, 1);
+    assert_eq!(enriched.notification_partition_id, 0);
+    assert_eq!(enriched.notification_partition_offset, 42);
+    assert!(enriched.notification_read_timestamp > 0);
+}
+
+#[test]
+fn enriched_notification_different_partitions() {
+    let json = r#"{
+        "bucket": "bucket",
+        "key": "key",
+        "size": 100,
+        "topic": "t",
+        "headerSize": 10,
+        "numBatchMessages": 1,
+        "numAttempts": 1
+    }"#;
+
+    let e1 = EnrichedNotification::from_json(json, 2, 100).unwrap();
+    let e2 = EnrichedNotification::from_json(json, 3, 200).unwrap();
+    assert_eq!(e1.notification_partition_id, 2);
+    assert_eq!(e2.notification_partition_id, 3);
+    assert_eq!(e1.notification_partition_offset, 100);
+    assert_eq!(e2.notification_partition_offset, 200);
+}
+
+#[test]
+fn enriched_notification_missing_field() {
+    let json = r#"{ "bucket": "b" }"#;
+    let result = EnrichedNotification::from_json(json, 0, 0);
+    assert!(result.is_err());
+}
+
+#[test]
+fn enriched_notification_invalid_json() {
+    let result = EnrichedNotification::from_json("not json", 0, 0);
+    assert!(result.is_err());
+}


### PR DESCRIPTION
Full implementation of a Rust consumer for MemQ with:
- MemQ wire format parser (batch header, message header, CRC32)
- Kafka notification source with blocking poll fix (background thread + sync_channel)
- Storage handler abstraction (filesystem + S3)
- Integration tests via Docker Kafka (docker-compose)
- E2E example: Java producer -> MemQ broker (fs) -> Kafka -> Rust consumer
- run-e2e.sh: automated end-to-end test script