### PR TITLE
Fix broker ZK missing registration

### DIFF
--- a/memq/pom.xml
+++ b/memq/pom.xml
@@ -176,6 +176,18 @@
 			</exclusions>
 		</dependency>
 		<dependency>
+			<groupId>org.apache.curator</groupId>
+			<artifactId>curator-test</artifactId>
+			<version>5.2.0</version>
+			<scope>test</scope>
+			<exclusions>
+				<exclusion>
+					<groupId>io.netty</groupId>
+					<artifactId>*</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+		<dependency>
 			<groupId>commons-cli</groupId>
 			<artifactId>commons-cli</artifactId>
 			<version>1.4</version>

--- a/memq/src/main/java/com/pinterest/memq/core/clustering/MemqGovernor.java
+++ b/memq/src/main/java/com/pinterest/memq/core/clustering/MemqGovernor.java
@@ -20,6 +20,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -31,9 +33,12 @@ import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.framework.recipes.leader.LeaderSelector;
 import org.apache.curator.framework.recipes.leader.LeaderSelectorListener;
 import org.apache.curator.framework.state.ConnectionState;
+import org.apache.curator.framework.state.ConnectionStateListener;
 import org.apache.curator.retry.ExponentialBackoffRetry;
 import org.apache.zookeeper.CreateMode;
+import org.apache.zookeeper.KeeperException;
 
+import com.codahale.metrics.MetricRegistry;
 import com.google.gson.Gson;
 import com.pinterest.memq.commons.protocol.Broker;
 import com.pinterest.memq.commons.protocol.TopicAssignment;
@@ -51,6 +56,8 @@ public class MemqGovernor {
   public static final String ZNODE_BROKERS = "/brokers";
   public static final String ZNODE_TOPICS_BASE = "/topics/";
   public static final String ZNODE_TOPICS = "/topics";
+  public static final String METRIC_BROKER_ZNODE_MISSING = "broker.znode.missing";
+  public static final String METRIC_BROKER_REREGISTERED = "broker.znode.reregistered";
   private static final Gson GSON = new Gson();
   private static final Logger logger = Logger.getLogger(MemqGovernor.class.getCanonicalName());
   private MemqConfig config;
@@ -62,6 +69,12 @@ public class MemqGovernor {
   private ClusteringConfig clusteringConfig;
   private String brokerZnodePath;
   private volatile boolean closed = false;
+  private MetricRegistry metricRegistry;
+  private final ExecutorService reRegistrationExecutor = Executors.newSingleThreadExecutor(r -> {
+    Thread t = new Thread(r, "BrokerReRegistration");
+    t.setDaemon(true);
+    return t;
+  });
 
   public MemqGovernor(MemqManager mgr, MemqConfig config, EnvironmentProvider provider) {
     this.mgr = mgr;
@@ -104,6 +117,36 @@ public class MemqGovernor {
     client.start();
     client.blockUntilConnected(100, TimeUnit.SECONDS);
     logger.info("Connected to zookeeper:" + zookeeperConnectionString);
+
+    // Reuse the shared registry map so the clustering counters are exported alongside
+    // the other "_"-prefixed (non-topic) metrics.
+    Map<String, MetricRegistry> registryMap = mgr.getRegistry();
+    metricRegistry = registryMap != null
+        ? registryMap.computeIfAbsent("_cluster", k -> new MetricRegistry())
+        : new MetricRegistry();
+
+    // The broker registers itself as an EPHEMERAL znode that is tied to the ZK
+    // session. When the session expires (SUSPENDED -> LOST), ZooKeeper deletes the
+    // node server-side and Curator establishes a brand new session. Without this
+    // listener nothing recreates the broker znode and the broker stays invisible to
+    // the cluster until it is restarted. Re-announce the broker on every RECONNECTED.
+    client.getConnectionStateListenable().addListener(new ConnectionStateListener() {
+      @Override
+      public void stateChanged(CuratorFramework cf, ConnectionState newState) {
+        logger.info("Curator connection state changed:" + newState);
+        if (closed) {
+          return;
+        }
+        if (newState == ConnectionState.LOST) {
+          // Session expired: ZooKeeper has dropped our ephemeral broker znode.
+          metricRegistry.counter(METRIC_BROKER_ZNODE_MISSING).inc();
+          logger.warning("ZK session lost, broker znode is now missing:" + brokerZnodePath);
+        } else if (newState == ConnectionState.RECONNECTED) {
+          // Run off the Curator event thread to avoid blocking it on ZK operations.
+          reRegisterBroker();
+        }
+      }
+    });
 
     initializeZNodesAndWatchers(client);
 
@@ -160,23 +203,83 @@ public class MemqGovernor {
       client.create().withMode(CreateMode.PERSISTENT).forPath(ZNODE_BROKERS);
     }
 
-    Broker broker = new Broker(provider.getIP(), config.getNettyServerConfig().getPort(),
-        provider.getInstanceType(), provider.getRack(), config.getBrokerType(),
-        mgr.getTopicAssignment());
-
-    brokerZnodePath = ZNODE_BROKERS_BASE + broker.getBrokerIP();
-    if (client.checkExists().forPath(brokerZnodePath) != null) {
-      client.delete().forPath(brokerZnodePath);
-    }
-    client.create().withMode(CreateMode.EPHEMERAL).forPath(brokerZnodePath,
-        GSON.toJson(broker).getBytes());
+    Broker broker = registerBroker(false);
 
     if (clusteringConfig.isEnableLocalAssigner()) {
-      Thread th = new Thread(new TopicAssignmentWatcher(mgr, brokerZnodePath, broker, client));
+      Thread th = new Thread(
+          new TopicAssignmentWatcher(mgr, brokerZnodePath, broker, client, this::reRegisterBroker));
       th.setDaemon(true);
       th.setName("TopicAssignmentWatcher");
       th.start();
     }
+  }
+
+  /**
+   * Idempotently (re)creates this broker's EPHEMERAL znode under {@code /brokers/<ip>}.
+   *
+   * <p>
+   * A fresh {@link Broker} snapshot is built on every call so the published znode always
+   * reflects the broker's current topic assignment (the assignment can change between the
+   * initial registration and a later re-registration triggered by a ZK session expiry).
+   * The method tolerates the races inherent to recreating an ephemeral node whose previous
+   * incarnation may still be lingering on the just-expired session.
+   * </p>
+   */
+  synchronized Broker registerBroker(boolean reRegistration) throws Exception {
+    Broker broker = new Broker(provider.getIP(), config.getNettyServerConfig().getPort(),
+        provider.getInstanceType(), provider.getRack(), config.getBrokerType(),
+        mgr.getTopicAssignment());
+    brokerZnodePath = ZNODE_BROKERS_BASE + broker.getBrokerIP();
+    if (closed) {
+      return broker;
+    }
+    byte[] brokerData = GSON.toJson(broker).getBytes();
+    // Parent could be missing if it never existed yet; ensure it before the child create.
+    if (client.checkExists().forPath(ZNODE_BROKERS) == null) {
+      try {
+        client.create().withMode(CreateMode.PERSISTENT).forPath(ZNODE_BROKERS);
+      } catch (KeeperException.NodeExistsException ignore) {
+        // created concurrently, fine
+      }
+    }
+    try {
+      if (client.checkExists().forPath(brokerZnodePath) != null) {
+        client.delete().forPath(brokerZnodePath);
+      }
+      client.create().withMode(CreateMode.EPHEMERAL).forPath(brokerZnodePath, brokerData);
+      logger.info("Registered broker ephemeral znode:" + brokerZnodePath);
+    } catch (KeeperException.NodeExistsException e) {
+      // A stale ephemeral from the prior (expired) session may briefly linger, or a
+      // concurrent re-registration won the race. Refresh the payload and move on.
+      client.setData().forPath(brokerZnodePath, brokerData);
+      logger.info("Broker znode already existed, refreshed data:" + brokerZnodePath);
+    } catch (KeeperException.NoNodeException e) {
+      // delete() raced with another deletion; the node is gone so just (re)create it.
+      client.create().withMode(CreateMode.EPHEMERAL).forPath(brokerZnodePath, brokerData);
+      logger.info("Re-created broker ephemeral znode after NoNode race:" + brokerZnodePath);
+    }
+    if (reRegistration) {
+      metricRegistry.counter(METRIC_BROKER_REREGISTERED).inc();
+    }
+    return broker;
+  }
+
+  /**
+   * Best-effort, non-throwing re-registration used as a recovery callback (e.g. when the
+   * {@link TopicAssignmentWatcher} notices the broker znode has vanished). The primary
+   * recovery path remains the {@link ConnectionStateListener}; this is a safety net.
+   */
+  void reRegisterBroker() {
+    if (closed) {
+      return;
+    }
+    reRegistrationExecutor.submit(() -> {
+      try {
+        registerBroker(true);
+      } catch (Exception e) {
+        logger.log(Level.SEVERE, "Failed to re-register broker znode", e);
+      }
+    });
   }
 
   public Map<String, TopicMetadata> getTopicMetadataMap() {
@@ -188,6 +291,10 @@ public class MemqGovernor {
   }
 
   public void stop() {
+    // Flip closed first so any in-flight RECONNECTED callback short-circuits instead of
+    // racing the shutdown by recreating the broker znode we are about to delete.
+    closed = true;
+    reRegistrationExecutor.shutdownNow();
     if (brokerZnodePath != null && client != null) {
       try {
         // best effort remove broker znode during shutdown
@@ -197,9 +304,17 @@ public class MemqGovernor {
             "Failed to deregister broker znode, will be removed after session timeout", e);
       }
     }
-    closed = true;
-    leaderSelector.close();
-    client.close();
+    if (leaderSelector != null) {
+      try {
+        leaderSelector.close();
+      } catch (IllegalStateException e) {
+        // leader selector may not have been started (e.g. disabled via config); ignore
+        logger.log(Level.FINE, "Leader selector was not started, skipping close", e);
+      }
+    }
+    if (client != null) {
+      client.close();
+    }
   }
 
   public void createTopic(TopicConfig topipConfig) throws Exception {

--- a/memq/src/main/java/com/pinterest/memq/core/clustering/TopicAssignmentWatcher.java
+++ b/memq/src/main/java/com/pinterest/memq/core/clustering/TopicAssignmentWatcher.java
@@ -16,9 +16,11 @@
 package com.pinterest.memq.core.clustering;
 
 import java.util.Set;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import org.apache.curator.framework.CuratorFramework;
+import org.apache.zookeeper.KeeperException;
 
 import com.google.common.collect.Sets;
 import com.google.gson.Gson;
@@ -37,14 +39,24 @@ public final class TopicAssignmentWatcher implements Runnable {
   private final String path;
   private final CuratorFramework client;
   private MemqManager mgr;
+  private final Runnable onMissingZnode;
 
   public TopicAssignmentWatcher(MemqManager mgr,
                                 String path,
                                 Broker broker,
                                 CuratorFramework client) {
+    this(mgr, path, broker, client, null);
+  }
+
+  public TopicAssignmentWatcher(MemqManager mgr,
+                                String path,
+                                Broker broker,
+                                CuratorFramework client,
+                                Runnable onMissingZnode) {
     this.mgr = mgr;
     this.path = path;
     this.client = client;
+    this.onMissingZnode = onMissingZnode;
   }
 
   @Override
@@ -87,15 +99,23 @@ public final class TopicAssignmentWatcher implements Runnable {
         if (updated) {
           mgr.updateTopicCache();
         }
+      } catch (KeeperException.NoNodeException e) {
+        // The broker's ephemeral znode is gone, most likely because the ZK session
+        // expired and ZooKeeper deleted it server-side. Don't spam stack traces on the
+        // tight poll loop; log distinctly and ask the governor to re-announce the broker.
+        logger.log(Level.WARNING,
+            "Broker znode is missing at " + path + "; requesting re-registration");
+        if (onMissingZnode != null) {
+          onMissingZnode.run();
+        }
       } catch (Exception e) {
-        // TODO Auto-generated catch block
-        e.printStackTrace();
+        logger.log(Level.WARNING, "Failed to poll topic assignment from " + path, e);
       }
       try {
         Thread.sleep(2000);
       } catch (InterruptedException e) {
-        // TODO Auto-generated catch block
-        e.printStackTrace();
+        Thread.currentThread().interrupt();
+        return;
       }
     }
   }

--- a/memq/src/test/java/com/pinterest/memq/core/clustering/TestMemqGovernor.java
+++ b/memq/src/test/java/com/pinterest/memq/core/clustering/TestMemqGovernor.java
@@ -16,16 +16,34 @@
 package com.pinterest.memq.core.clustering;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.io.FileNotFoundException;
 import java.io.FileReader;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.test.KillSession;
+import org.apache.curator.test.TestingServer;
+import org.apache.zookeeper.ZooKeeper;
 import org.junit.Test;
 
+import com.codahale.metrics.MetricRegistry;
 import com.google.gson.Gson;
 import com.google.gson.JsonIOException;
 import com.google.gson.JsonSyntaxException;
+import com.pinterest.memq.commons.protocol.Broker.BrokerType;
 import com.pinterest.memq.commons.protocol.TopicConfig;
+import com.pinterest.memq.core.MemqManager;
+import com.pinterest.memq.core.config.ClusteringConfig;
+import com.pinterest.memq.core.config.EnvironmentProvider;
+import com.pinterest.memq.core.config.MemqConfig;
+import com.pinterest.memq.core.config.NettyServerConfig;
 
 public class TestMemqGovernor {
 
@@ -39,6 +57,103 @@ public class TestMemqGovernor {
         TopicConfig.class);
     assertEquals("customs3aync2", oldConf.getStorageHandlerName());
     assertEquals("customs3aync2", newConf.getStorageHandlerName());
+  }
+
+  /**
+   * Simulates a ZooKeeper session expiry and verifies that the broker re-creates its
+   * ephemeral {@code /brokers/<ip>} znode automatically, without a process restart.
+   */
+  @Test
+  public void testBrokerReRegistersAfterSessionExpiry() throws Exception {
+    String brokerIp = "10.0.0.42";
+    String expectedPath = MemqGovernor.ZNODE_BROKERS_BASE + brokerIp;
+
+    try (TestingServer testingServer = new TestingServer()) {
+      ClusteringConfig clusteringConfig = new ClusteringConfig();
+      clusteringConfig.setZookeeperConnectionString(testingServer.getConnectString());
+      // Keep the test focused on registration; disable the extra background machinery.
+      clusteringConfig.setEnableBalancer(false);
+      clusteringConfig.setEnableLeaderSelector(false);
+      clusteringConfig.setEnableLocalAssigner(false);
+
+      NettyServerConfig nettyServerConfig = mock(NettyServerConfig.class);
+      when(nettyServerConfig.getPort()).thenReturn((short) 9092);
+
+      MemqConfig config = mock(MemqConfig.class);
+      when(config.getTopicConfig()).thenReturn(null);
+      when(config.getClusteringConfig()).thenReturn(clusteringConfig);
+      when(config.getNettyServerConfig()).thenReturn(nettyServerConfig);
+      when(config.getBrokerType()).thenReturn(BrokerType.WRITE);
+
+      EnvironmentProvider provider = mock(EnvironmentProvider.class);
+      when(provider.getIP()).thenReturn(brokerIp);
+      when(provider.getInstanceType()).thenReturn("test-instance");
+      when(provider.getRack()).thenReturn("test-rack");
+
+      Map<String, MetricRegistry> registryMap = new HashMap<>();
+      MemqManager mgr = mock(MemqManager.class);
+      when(mgr.getTopicAssignment()).thenReturn(Collections.emptySet());
+      when(mgr.getRegistry()).thenReturn(registryMap);
+
+      MemqGovernor governor = new MemqGovernor(mgr, config, provider);
+      try {
+        governor.init();
+        CuratorFramework client = governor.getCuratorFramework();
+
+        assertNotNull("broker znode should exist after init",
+            client.checkExists().forPath(expectedPath));
+
+        // Force the current ZK session to expire. ZooKeeper deletes the ephemeral
+        // broker znode server-side as a result.
+        ZooKeeper zk = client.getZookeeperClient().getZooKeeper();
+        KillSession.kill(zk);
+
+        // After Curator establishes a new session and fires RECONNECTED, the governor's
+        // ConnectionStateListener must recreate the ephemeral broker znode.
+        assertTrue("broker znode should be re-created automatically after session expiry",
+            waitForPath(client, expectedPath, 60_000));
+
+        MetricRegistry clusterRegistry = registryMap.get("_cluster");
+        assertNotNull("cluster metric registry should be created", clusterRegistry);
+        assertTrue("missing znode metric should be emitted",
+            clusterRegistry.counter(MemqGovernor.METRIC_BROKER_ZNODE_MISSING).getCount() >= 1);
+        // Re-registration is performed asynchronously off the Curator event thread.
+        assertTrue("re-registration metric should be emitted",
+            waitForCounter(clusterRegistry, MemqGovernor.METRIC_BROKER_REREGISTERED, 30_000));
+      } finally {
+        governor.stop();
+      }
+    }
+  }
+
+  private static boolean waitForCounter(MetricRegistry registry,
+                                        String name,
+                                        long timeoutMs) throws InterruptedException {
+    long deadline = System.currentTimeMillis() + timeoutMs;
+    while (System.currentTimeMillis() < deadline) {
+      if (registry.counter(name).getCount() >= 1) {
+        return true;
+      }
+      Thread.sleep(200);
+    }
+    return false;
+  }
+
+  private static boolean waitForPath(CuratorFramework client,
+                                     String path,
+                                     long timeoutMs) throws Exception {
+    long deadline = System.currentTimeMillis() + timeoutMs;
+    while (System.currentTimeMillis() < deadline) {
+      try {
+        if (client.checkExists().forPath(path) != null) {
+          return true;
+        }
+      } catch (Exception ignore) {
+        // connection may be momentarily unavailable during the new-session handshake
+      }
+      Thread.sleep(200);
+    }
+    return false;
   }
 
 }


### PR DESCRIPTION
## Fix: broker fails to re-register in ZooKeeper after session expiry

### Problem
After a ZooKeeper session expiry (`SUSPENDED → SessionExpired → LOST`), a broker's
ephemeral `/brokers/<ip>` znode is deleted server-side. Curator establishes a brand new
session, but nothing recreated the znode, so the broker stayed invisible to the
cluster/metadata until the process was manually restarted. Additionally,
`TopicAssignmentWatcher` polled the now-missing znode and spammed `printStackTrace()`
on a tight 2s loop.

### Root cause
The broker registered its EPHEMERAL znode exactly once, at startup, inside
`initializeZNodesAndWatchers(...)`. There was no `ConnectionStateListener` on the Curator
client to re-announce the broker on reconnect, and the only state handler present (on the
`LeaderSelector`) merely logged.

### Changes
- **`MemqGovernor`**
  - Extracted ephemeral-znode creation into an idempotent `registerBroker(boolean reRegistration)`
    that builds a **fresh `Broker` snapshot** each call (so re-registration reflects the
    current topic assignment) and tolerates recreate races (`NodeExists` → refresh data,
    `NoNode` → recreate).
  - Registered a `ConnectionStateListener` on the Curator client that re-announces the broker
    on `RECONNECTED`. Re-registration runs on a dedicated single-thread daemon executor to
    avoid blocking the Curator event thread, and short-circuits when shutting down.
  - Hardened `stop()`: flips `closed` first (so an in-flight reconnect callback can't recreate
    the znode we're deleting), shuts down the executor, and guards `leaderSelector.close()` /
    `client.close()` against the not-started / null cases.
- **`TopicAssignmentWatcher`**
  - Handles `NoNodeException` distinctly: logs a single clear warning and invokes a
    re-registration callback instead of spamming stack traces; other exceptions log a warning;
    `InterruptedException` now exits the loop cleanly. Backward-compatible 4-arg constructor
    retained.
- **Metrics** (new `_cluster` registry pulled from `MemqManager.getRegistry()`, exported with
  the other `_`-prefixed non-topic metrics)
  - `broker.znode.missing` — emitted on `LOST` (the reliable signal the znode is gone; avoids
    false negatives from a stale ephemeral briefly lingering on the expired session).
  - `broker.znode.reregistered` — emitted on a successful reconnect/watcher-driven
    re-registration (not the initial startup registration).

### Tests
- Added `TestMemqGovernor#testBrokerReRegistersAfterSessionExpiry`: spins up a Curator
  `TestingServer`, registers the broker, force-expires the session via `KillSession`, and
  asserts the `/brokers/<ip>` znode is recreated automatically and both metrics are emitted.
- Added the `curator-test` (5.2.0, test scope) dependency.

### Acceptance criteria
- ✅ After a forced ZK session expiry, the broker re-creates its ephemeral znode automatically
  (no restart needed).
- ✅ No tight error loop in `TopicAssignmentWatcher` when the node is briefly missing.
- ✅ Test simulating session expiry confirms re-registration.